### PR TITLE
feat(backend): SQLAlchemy Models — 8 tables (#5)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,19 @@
+from app.models.ai_insight import AIInsight
+from app.models.alert_log import AlertLog
+from app.models.collector_log import CollectorLog
+from app.models.daily_brief import DailyBrief
+from app.models.keyword import Keyword
+from app.models.keyword_alert import KeywordAlert
+from app.models.platform import Platform
+from app.models.trend import Trend
+
+__all__ = [
+    "AIInsight",
+    "AlertLog",
+    "CollectorLog",
+    "DailyBrief",
+    "Keyword",
+    "KeywordAlert",
+    "Platform",
+    "Trend",
+]

--- a/backend/app/models/ai_insight.py
+++ b/backend/app/models/ai_insight.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.trend import Trend
+
+
+class AIInsight(Base):
+    __tablename__ = "ai_insights"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    trend_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("trends.id", ondelete="SET NULL"), nullable=True
+    )
+    insight_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    model: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+
+    trend: Mapped[Optional[Trend]] = relationship("Trend", back_populates="ai_insights")
+
+    def __repr__(self) -> str:
+        return f"<AIInsight id={self.id} type={self.insight_type!r}>"

--- a/backend/app/models/alert_log.py
+++ b/backend/app/models/alert_log.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.keyword import Keyword
+
+
+class AlertLog(Base):
+    __tablename__ = "alert_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    keyword_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("keywords.id", ondelete="SET NULL"), nullable=True
+    )
+    triggered_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+    matched_keywords: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    notified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    keyword_rel: Mapped[Optional[Keyword]] = relationship("Keyword", back_populates="alert_logs")
+
+    def __repr__(self) -> str:
+        return f"<AlertLog id={self.id} keyword_id={self.keyword_id}>"

--- a/backend/app/models/collector_log.py
+++ b/backend/app/models/collector_log.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class CollectorLog(Base):
+    __tablename__ = "collector_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    records_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    error_msg: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    run_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<CollectorLog id={self.id} platform={self.platform!r} status={self.status!r}>"

--- a/backend/app/models/daily_brief.py
+++ b/backend/app/models/daily_brief.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class DailyBrief(Base):
+    __tablename__ = "daily_briefs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    date: Mapped[date] = mapped_column(Date, nullable=False, unique=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    model: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<DailyBrief id={self.id} date={self.date}>"

--- a/backend/app/models/keyword.py
+++ b/backend/app/models/keyword.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Boolean, DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.alert_log import AlertLog
+    from app.models.keyword_alert import KeywordAlert
+
+
+class Keyword(Base):
+    __tablename__ = "keywords"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    keyword: Mapped[str] = mapped_column(String(200), nullable=False, unique=True)
+    category: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+
+    alerts: Mapped[list[KeywordAlert]] = relationship("KeywordAlert", back_populates="keyword_rel")
+    alert_logs: Mapped[list[AlertLog]] = relationship("AlertLog", back_populates="keyword_rel")
+
+    def __repr__(self) -> str:
+        return f"<Keyword id={self.id} keyword={self.keyword!r}>"

--- a/backend/app/models/keyword_alert.py
+++ b/backend/app/models/keyword_alert.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Boolean, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.keyword import Keyword
+
+
+class KeywordAlert(Base):
+    __tablename__ = "keyword_alerts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    keyword_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("keywords.id", ondelete="CASCADE"), nullable=False
+    )
+    threshold: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    notify_email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    keyword_rel: Mapped[Keyword] = relationship("Keyword", back_populates="alerts")
+
+    def __repr__(self) -> str:
+        return f"<KeywordAlert id={self.id} keyword_id={self.keyword_id}>"

--- a/backend/app/models/platform.py
+++ b/backend/app/models/platform.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.trend import Trend
+
+
+class Platform(Base):
+    __tablename__ = "platforms"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    slug: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    config_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+
+    trends: Mapped[list[Trend]] = relationship("Trend", back_populates="platform_rel")
+
+    def __repr__(self) -> str:
+        return f"<Platform id={self.id} slug={self.slug!r}>"

--- a/backend/app/models/trend.py
+++ b/backend/app/models/trend.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.ai_insight import AIInsight
+    from app.models.platform import Platform
+
+
+class Trend(Base):
+    __tablename__ = "trends"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("platforms.id", ondelete="SET NULL"), nullable=True
+    )
+    platform: Mapped[str] = mapped_column(String(50), nullable=False)
+    keyword: Mapped[str] = mapped_column(String(200), nullable=False)
+    rank: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    heat_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    collected_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+    url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+
+    platform_rel: Mapped[Optional[Platform]] = relationship("Platform", back_populates="trends")
+    ai_insights: Mapped[list[AIInsight]] = relationship("AIInsight", back_populates="trend")
+
+    def __repr__(self) -> str:
+        return f"<Trend id={self.id} platform={self.platform!r} keyword={self.keyword!r}>"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,85 @@
+"""Tests for SQLAlchemy model definitions (import and attribute checks)."""
+import pytest
+
+from app.models import (
+    AIInsight,
+    AlertLog,
+    CollectorLog,
+    DailyBrief,
+    Keyword,
+    KeywordAlert,
+    Platform,
+    Trend,
+)
+
+
+def test_platform_tablename():
+    assert Platform.__tablename__ == "platforms"
+
+
+def test_trend_tablename():
+    assert Trend.__tablename__ == "trends"
+
+
+def test_keyword_tablename():
+    assert Keyword.__tablename__ == "keywords"
+
+
+def test_keyword_alert_tablename():
+    assert KeywordAlert.__tablename__ == "keyword_alerts"
+
+
+def test_ai_insight_tablename():
+    assert AIInsight.__tablename__ == "ai_insights"
+
+
+def test_daily_brief_tablename():
+    assert DailyBrief.__tablename__ == "daily_briefs"
+
+
+def test_alert_log_tablename():
+    assert AlertLog.__tablename__ == "alert_logs"
+
+
+def test_collector_log_tablename():
+    assert CollectorLog.__tablename__ == "collector_logs"
+
+
+def test_platform_columns():
+    cols = {c.name for c in Platform.__table__.columns}
+    assert {"id", "name", "slug", "is_active", "config_json", "created_at"} <= cols
+
+
+def test_trend_columns():
+    cols = {c.name for c in Trend.__table__.columns}
+    assert {"id", "platform", "keyword", "rank", "heat_score", "collected_at", "url"} <= cols
+
+
+def test_keyword_columns():
+    cols = {c.name for c in Keyword.__table__.columns}
+    assert {"id", "keyword", "category", "is_active", "created_at"} <= cols
+
+
+def test_keyword_alert_columns():
+    cols = {c.name for c in KeywordAlert.__table__.columns}
+    assert {"id", "keyword_id", "threshold", "notify_email", "is_active"} <= cols
+
+
+def test_ai_insight_columns():
+    cols = {c.name for c in AIInsight.__table__.columns}
+    assert {"id", "trend_id", "insight_type", "content", "model", "created_at"} <= cols
+
+
+def test_daily_brief_columns():
+    cols = {c.name for c in DailyBrief.__table__.columns}
+    assert {"id", "date", "content", "model", "created_at"} <= cols
+
+
+def test_alert_log_columns():
+    cols = {c.name for c in AlertLog.__table__.columns}
+    assert {"id", "keyword_id", "triggered_at", "matched_keywords", "notified"} <= cols
+
+
+def test_collector_log_columns():
+    cols = {c.name for c in CollectorLog.__table__.columns}
+    assert {"id", "platform", "status", "records_count", "error_msg", "run_at"} <= cols


### PR DESCRIPTION
## Summary
- Add 8 SQLAlchemy 2.0 ORM models: Platform, Trend, Keyword, KeywordAlert, AIInsight, DailyBrief, AlertLog, CollectorLog
- Use Mapped/mapped_column syntax with TYPE_CHECKING for forward refs
- Foreign key relationships with proper ondelete cascade/set-null

## Test plan
- [x] 16 unit tests pass (tests/test_models.py)
- [x] ruff + black clean

Closes #5