### PR TITLE
feat(backend): BaseCollector + CollectorRegistry + WeiboMockCollector (#6)

### DIFF
--- a/backend/app/collectors/__init__.py
+++ b/backend/app/collectors/__init__.py
@@ -1,0 +1,8 @@
+from app.collectors.base import BaseCollector
+from app.collectors.registry import CollectorRegistry, registry
+from app.collectors.weibo_mock import WeiboMockCollector
+
+# Auto-register bundled collectors
+registry.register(WeiboMockCollector)
+
+__all__ = ["BaseCollector", "CollectorRegistry", "WeiboMockCollector", "registry"]

--- a/backend/app/collectors/base.py
+++ b/backend/app/collectors/base.py
@@ -1,0 +1,34 @@
+"""Abstract base class for all data collectors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import UTC, datetime
+
+
+class BaseCollector(ABC):
+    """Abstract base for platform trend collectors.
+
+    Each concrete collector must implement :meth:`collect` and declare a
+    ``platform`` class attribute that identifies it in the registry.
+    """
+
+    platform: str = ""
+
+    @abstractmethod
+    async def collect(self) -> list[dict]:
+        """Fetch trend data from the platform.
+
+        Returns:
+            A list of dicts, each containing at minimum:
+            - platform (str)
+            - keyword (str)
+            - rank (int | None)
+            - heat_score (float | None)
+            - url (str | None)
+            - collected_at (datetime)
+        """
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(UTC)

--- a/backend/app/collectors/registry.py
+++ b/backend/app/collectors/registry.py
@@ -1,0 +1,52 @@
+"""Collector registry — plug-in manager for platform collectors."""
+
+from __future__ import annotations
+
+from typing import Type
+
+from app.collectors.base import BaseCollector
+
+
+class CollectorRegistry:
+    """Central registry that maps platform slugs to collector classes."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, Type[BaseCollector]] = {}
+
+    def register(self, collector_cls: Type[BaseCollector]) -> Type[BaseCollector]:
+        """Register a collector class by its ``platform`` attribute.
+
+        Can be used as a decorator::
+
+            @registry.register
+            class MyCollector(BaseCollector):
+                platform = "my_platform"
+        """
+        if not collector_cls.platform:
+            raise ValueError(
+                f"Collector {collector_cls.__name__} must define a non-empty 'platform' attribute."
+            )
+        self._registry[collector_cls.platform] = collector_cls
+        return collector_cls
+
+    def get(self, platform: str) -> Type[BaseCollector]:
+        """Return the collector class for *platform*.
+
+        Raises:
+            KeyError: If no collector is registered for the given platform slug.
+        """
+        if platform not in self._registry:
+            raise KeyError(f"No collector registered for platform '{platform}'.")
+        return self._registry[platform]
+
+    def list_platforms(self) -> list[str]:
+        """Return sorted list of registered platform slugs."""
+        return sorted(self._registry.keys())
+
+    def all(self) -> dict[str, Type[BaseCollector]]:
+        """Return a copy of the full registry mapping."""
+        return dict(self._registry)
+
+
+# Global singleton registry used across the application.
+registry = CollectorRegistry()

--- a/backend/app/collectors/weibo_mock.py
+++ b/backend/app/collectors/weibo_mock.py
@@ -1,0 +1,44 @@
+"""Weibo mock collector — returns static fixture data for testing."""
+
+from __future__ import annotations
+
+from app.collectors.base import BaseCollector
+
+_MOCK_TRENDS = [
+    {"keyword": "ChatGPT最新版", "rank": 1, "heat_score": 9800.0, "url": "https://weibo.com/hot/1"},
+    {
+        "keyword": "春节档电影票房",
+        "rank": 2,
+        "heat_score": 8500.0,
+        "url": "https://weibo.com/hot/2",
+    },
+    {"keyword": "A股行情", "rank": 3, "heat_score": 7200.0, "url": "https://weibo.com/hot/3"},
+    {"keyword": "世界杯预选赛", "rank": 4, "heat_score": 6100.0, "url": "https://weibo.com/hot/4"},
+    {
+        "keyword": "国产大模型发布",
+        "rank": 5,
+        "heat_score": 5500.0,
+        "url": "https://weibo.com/hot/5",
+    },
+]
+
+
+class WeiboMockCollector(BaseCollector):
+    """Mock collector for Weibo — returns fixed test data without network I/O."""
+
+    platform = "weibo"
+
+    async def collect(self) -> list[dict]:
+        """Return static mock trend data for Weibo."""
+        now = self._now()
+        return [
+            {
+                "platform": self.platform,
+                "keyword": item["keyword"],
+                "rank": item["rank"],
+                "heat_score": item["heat_score"],
+                "url": item["url"],
+                "collected_at": now,
+            }
+            for item in _MOCK_TRENDS
+        ]

--- a/backend/tests/test_collectors.py
+++ b/backend/tests/test_collectors.py
@@ -1,0 +1,158 @@
+"""Unit tests for BaseCollector, CollectorRegistry, and WeiboMockCollector."""
+from __future__ import annotations
+
+import pytest
+
+from app.collectors.base import BaseCollector
+from app.collectors.registry import CollectorRegistry
+from app.collectors.weibo_mock import WeiboMockCollector
+
+
+# ---------------------------------------------------------------------------
+# BaseCollector — abstract interface
+# ---------------------------------------------------------------------------
+
+
+def test_base_collector_is_abstract():
+    """Cannot instantiate BaseCollector directly."""
+    with pytest.raises(TypeError):
+        BaseCollector()  # type: ignore[abstract]
+
+
+def test_concrete_collector_must_implement_collect():
+    """A subclass that doesn't implement collect() is still abstract."""
+
+    class IncompleteCollector(BaseCollector):
+        platform = "test"
+
+    with pytest.raises(TypeError):
+        IncompleteCollector()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# CollectorRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_and_get():
+    reg = CollectorRegistry()
+
+    class DummyCollector(BaseCollector):
+        platform = "dummy"
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    reg.register(DummyCollector)
+    assert reg.get("dummy") is DummyCollector
+
+
+def test_registry_list_platforms():
+    reg = CollectorRegistry()
+
+    class AlphaCollector(BaseCollector):
+        platform = "alpha"
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    class BetaCollector(BaseCollector):
+        platform = "beta"
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    reg.register(AlphaCollector)
+    reg.register(BetaCollector)
+    assert reg.list_platforms() == ["alpha", "beta"]
+
+
+def test_registry_get_unknown_raises_key_error():
+    reg = CollectorRegistry()
+    with pytest.raises(KeyError):
+        reg.get("nonexistent")
+
+
+def test_registry_register_without_platform_raises():
+    reg = CollectorRegistry()
+
+    class NoPlatformCollector(BaseCollector):
+        platform = ""
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    with pytest.raises(ValueError):
+        reg.register(NoPlatformCollector)
+
+
+def test_registry_decorator_usage():
+    """register() can be used as a decorator."""
+    reg = CollectorRegistry()
+
+    @reg.register
+    class DecoratedCollector(BaseCollector):
+        platform = "decorated"
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    assert "decorated" in reg.list_platforms()
+
+
+def test_registry_all_returns_copy():
+    reg = CollectorRegistry()
+
+    class C(BaseCollector):
+        platform = "c"
+
+        async def collect(self) -> list[dict]:
+            return []
+
+    reg.register(C)
+    snap = reg.all()
+    snap["injected"] = C  # mutating the copy should not affect registry
+    assert "injected" not in reg.list_platforms()
+
+
+# ---------------------------------------------------------------------------
+# WeiboMockCollector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_weibo_mock_collector_platform():
+    assert WeiboMockCollector.platform == "weibo"
+
+
+@pytest.mark.asyncio
+async def test_weibo_mock_collector_returns_list():
+    collector = WeiboMockCollector()
+    results = await collector.collect()
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+
+@pytest.mark.asyncio
+async def test_weibo_mock_collector_record_schema():
+    collector = WeiboMockCollector()
+    results = await collector.collect()
+    required_keys = {"platform", "keyword", "rank", "heat_score", "url", "collected_at"}
+    for item in results:
+        assert required_keys <= set(item.keys()), f"Missing keys in record: {item}"
+
+
+@pytest.mark.asyncio
+async def test_weibo_mock_collector_platform_field():
+    collector = WeiboMockCollector()
+    results = await collector.collect()
+    for item in results:
+        assert item["platform"] == "weibo"
+
+
+@pytest.mark.asyncio
+async def test_weibo_mock_collector_rank_order():
+    collector = WeiboMockCollector()
+    results = await collector.collect()
+    ranks = [r["rank"] for r in results if r["rank"] is not None]
+    assert ranks == sorted(ranks), "Ranks should be in ascending order"


### PR DESCRIPTION
## Summary
- Add abstract BaseCollector with collect() method and UTC-aware _now() helper
- Add CollectorRegistry singleton for registering/retrieving collectors by platform slug
- Add WeiboMockCollector returning 5 fixed trend records for testing
- Auto-register WeiboMockCollector in collectors __init__

## Test plan
- [x] 13 unit tests pass (tests/test_collectors.py)
- [x] ruff + black clean

Closes #6