### PR TITLE
feat(backend): BaseLLMProvider + LLMFactory + MiniMaxProvider (#7)

### DIFF
--- a/backend/app/ai/__init__.py
+++ b/backend/app/ai/__init__.py
@@ -1,0 +1,12 @@
+from app.ai.base import AnalyzeResponse, BaseLLMProvider, ChatMessage, ChatResponse
+from app.ai.factory import LLMFactory
+from app.ai.minimax_provider import MiniMaxProvider
+
+__all__ = [
+    "AnalyzeResponse",
+    "BaseLLMProvider",
+    "ChatMessage",
+    "ChatResponse",
+    "LLMFactory",
+    "MiniMaxProvider",
+]

--- a/backend/app/ai/base.py
+++ b/backend/app/ai/base.py
@@ -1,0 +1,78 @@
+"""Abstract base class for all LLM providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ChatMessage:
+    """A single message in a chat conversation."""
+
+    role: str  # "system" | "user" | "assistant"
+    content: str
+
+
+@dataclass
+class ChatResponse:
+    """Normalised response from a chat completion."""
+
+    content: str
+    model: str
+    usage: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AnalyzeResponse:
+    """Normalised response from an analysis request."""
+
+    insight_type: str
+    content: str
+    model: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class BaseLLMProvider(ABC):
+    """Abstract interface that every LLM provider must implement.
+
+    Concrete providers should:
+    - declare a ``provider_name`` class attribute
+    - implement :meth:`chat` for free-form conversation
+    - implement :meth:`analyze` for structured trend analysis
+    """
+
+    provider_name: str = ""
+
+    @abstractmethod
+    async def chat(self, messages: list[ChatMessage], **kwargs: Any) -> ChatResponse:
+        """Send a list of messages and return the assistant reply.
+
+        Args:
+            messages: Ordered conversation history.
+            **kwargs: Provider-specific parameters (temperature, max_tokens, …).
+
+        Returns:
+            A :class:`ChatResponse` with the assistant content.
+        """
+
+    @abstractmethod
+    async def analyze(
+        self,
+        keyword: str,
+        context: str = "",
+        insight_type: str = "business",
+        **kwargs: Any,
+    ) -> AnalyzeResponse:
+        """Analyse a trend keyword and return structured insights.
+
+        Args:
+            keyword: The trend keyword to analyse.
+            context: Optional surrounding context (e.g. related keywords).
+            insight_type: Type of insight requested (e.g. "business", "sentiment").
+            **kwargs: Provider-specific parameters.
+
+        Returns:
+            An :class:`AnalyzeResponse` with the analysis content.
+        """

--- a/backend/app/ai/factory.py
+++ b/backend/app/ai/factory.py
@@ -1,0 +1,45 @@
+"""LLM provider factory — creates the correct provider from env config."""
+
+from __future__ import annotations
+
+from app.ai.base import BaseLLMProvider
+from app.config import settings
+
+
+class LLMFactory:
+    """Factory that instantiates the configured LLM provider.
+
+    The active provider is controlled by the ``LLM_PROVIDER`` environment
+    variable (mapped to :attr:`~app.config.Settings.llm_provider`).
+    Adding a new provider requires only:
+    1. Creating a subclass of :class:`~app.ai.base.BaseLLMProvider`.
+    2. Registering it in :attr:`_PROVIDERS` below.
+    """
+
+    _PROVIDERS: dict[str, str] = {
+        "minimax": "app.ai.minimax_provider.MiniMaxProvider",
+    }
+
+    @classmethod
+    def create(cls, provider_name: str | None = None) -> BaseLLMProvider:
+        """Return an instance of the configured LLM provider.
+
+        Args:
+            provider_name: Override the provider name from settings.
+                           Defaults to ``settings.llm_provider``.
+
+        Raises:
+            ValueError: If the requested provider is not registered.
+        """
+        name = (provider_name or settings.llm_provider).lower()
+        dotted_path = cls._PROVIDERS.get(name)
+        if dotted_path is None:
+            available = ", ".join(sorted(cls._PROVIDERS.keys()))
+            raise ValueError(f"Unknown LLM provider '{name}'. Available providers: {available}.")
+
+        module_path, class_name = dotted_path.rsplit(".", 1)
+        import importlib
+
+        module = importlib.import_module(module_path)
+        provider_cls = getattr(module, class_name)
+        return provider_cls()

--- a/backend/app/ai/minimax_provider.py
+++ b/backend/app/ai/minimax_provider.py
@@ -1,0 +1,57 @@
+"""MiniMax LLM provider stub — does not call the real API in this version."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.ai.base import AnalyzeResponse, BaseLLMProvider, ChatMessage, ChatResponse
+from app.config import settings
+
+
+class MiniMaxProvider(BaseLLMProvider):
+    """Stub implementation of the MiniMax LLM provider.
+
+    In the MVP phase this class returns deterministic placeholder responses so
+    that the rest of the application can be developed and tested without live
+    API credentials.  Replace the method bodies with real ``httpx`` calls once
+    you are ready to connect to the MiniMax API.
+    """
+
+    provider_name = "minimax"
+
+    def __init__(self) -> None:
+        self.api_key = settings.minimax_api_key
+        self.group_id = settings.minimax_group_id
+        self.model = "abab6.5s-chat"
+
+    async def chat(self, messages: list[ChatMessage], **kwargs: Any) -> ChatResponse:
+        """Return a stub chat reply (no real API call)."""
+        last_user = next(
+            (m.content for m in reversed(messages) if m.role == "user"),
+            "",
+        )
+        stub_content = f"[MiniMax stub] Received: {last_user[:80]}"
+        return ChatResponse(
+            content=stub_content,
+            model=self.model,
+            usage={"prompt_tokens": 0, "completion_tokens": 0},
+        )
+
+    async def analyze(
+        self,
+        keyword: str,
+        context: str = "",
+        insight_type: str = "business",
+        **kwargs: Any,
+    ) -> AnalyzeResponse:
+        """Return a stub analysis (no real API call)."""
+        stub_content = (
+            f"[MiniMax stub] Analysis for '{keyword}' "
+            f"(type={insight_type}): This is a placeholder insight. "
+            "Connect to the real MiniMax API to obtain genuine results."
+        )
+        return AnalyzeResponse(
+            insight_type=insight_type,
+            content=stub_content,
+            model=self.model,
+        )

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -1,0 +1,124 @@
+"""Unit tests for BaseLLMProvider, LLMFactory, and MiniMaxProvider."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.base import AnalyzeResponse, BaseLLMProvider, ChatMessage, ChatResponse
+from app.ai.factory import LLMFactory
+from app.ai.minimax_provider import MiniMaxProvider
+
+
+# ---------------------------------------------------------------------------
+# BaseLLMProvider — abstract interface
+# ---------------------------------------------------------------------------
+
+
+def test_base_provider_is_abstract():
+    """Cannot instantiate BaseLLMProvider directly."""
+    with pytest.raises(TypeError):
+        BaseLLMProvider()  # type: ignore[abstract]
+
+
+def test_concrete_provider_must_implement_both_methods():
+    """A subclass that implements only chat() remains abstract."""
+
+    class PartialProvider(BaseLLMProvider):
+        provider_name = "partial"
+
+        async def chat(self, messages, **kwargs):
+            return ChatResponse(content="ok", model="m")
+
+    with pytest.raises(TypeError):
+        PartialProvider()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# ChatMessage / ChatResponse / AnalyzeResponse dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_chat_message_fields():
+    msg = ChatMessage(role="user", content="hello")
+    assert msg.role == "user"
+    assert msg.content == "hello"
+
+
+def test_chat_response_defaults():
+    resp = ChatResponse(content="hi", model="gpt")
+    assert resp.usage == {}
+
+
+def test_analyze_response_defaults():
+    resp = AnalyzeResponse(insight_type="business", content="text", model="m")
+    assert resp.extra == {}
+
+
+# ---------------------------------------------------------------------------
+# MiniMaxProvider stub
+# ---------------------------------------------------------------------------
+
+
+def test_minimax_provider_name():
+    assert MiniMaxProvider.provider_name == "minimax"
+
+
+@pytest.mark.asyncio
+async def test_minimax_chat_returns_chat_response():
+    provider = MiniMaxProvider()
+    messages = [ChatMessage(role="user", content="Tell me about AI trends")]
+    resp = await provider.chat(messages)
+    assert isinstance(resp, ChatResponse)
+    assert resp.content  # non-empty
+    assert resp.model
+
+
+@pytest.mark.asyncio
+async def test_minimax_chat_echoes_user_message():
+    provider = MiniMaxProvider()
+    messages = [ChatMessage(role="user", content="Hello stub")]
+    resp = await provider.chat(messages)
+    assert "Hello stub" in resp.content
+
+
+@pytest.mark.asyncio
+async def test_minimax_analyze_returns_analyze_response():
+    provider = MiniMaxProvider()
+    resp = await provider.analyze(keyword="AI大模型", insight_type="business")
+    assert isinstance(resp, AnalyzeResponse)
+    assert resp.insight_type == "business"
+    assert resp.content
+    assert resp.model
+
+
+@pytest.mark.asyncio
+async def test_minimax_analyze_contains_keyword():
+    provider = MiniMaxProvider()
+    resp = await provider.analyze(keyword="量子计算")
+    assert "量子计算" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# LLMFactory
+# ---------------------------------------------------------------------------
+
+
+def test_llm_factory_creates_minimax():
+    provider = LLMFactory.create("minimax")
+    assert isinstance(provider, MiniMaxProvider)
+
+
+def test_llm_factory_case_insensitive():
+    provider = LLMFactory.create("MiniMax")
+    assert isinstance(provider, MiniMaxProvider)
+
+
+def test_llm_factory_unknown_provider_raises():
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        LLMFactory.create("openai")
+
+
+def test_llm_factory_default_uses_settings(monkeypatch):
+    monkeypatch.setattr("app.config.settings.llm_provider", "minimax")
+    provider = LLMFactory.create()
+    assert isinstance(provider, MiniMaxProvider)


### PR DESCRIPTION
## Summary
- Add BaseLLMProvider abstract class with chat() and analyze() abstract methods
- Add ChatMessage, ChatResponse, AnalyzeResponse dataclasses for typed I/O
- Add LLMFactory with dynamic import pattern reading LLM_PROVIDER env var
- Add MiniMaxProvider stub (no real API calls) ready for production wiring

## Test plan
- [x] 14 unit tests pass (tests/test_ai.py)
- [x] ruff + black clean

Closes #7