### PR TITLE
feat(backend): APScheduler integration + scheduler status endpoint (#8)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,14 +4,20 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.routers import scheduler as scheduler_router
+from app.services.scheduler import setup_scheduler
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     print(f"TrendTracker backend starting — LLM provider: {settings.llm_provider}")
+    sched = setup_scheduler()
+    sched.start()
+    print("APScheduler started")
     yield
     # Shutdown
+    sched.shutdown(wait=False)
     print("TrendTracker backend shutting down")
 
 
@@ -36,6 +42,4 @@ async def health():
     return {"status": "ok", "version": "0.1.0"}
 
 
-# Routers will be included here as features are built
-# from app.routers import trends, ai, collector, alerts
-# app.include_router(trends.router, prefix="/api/v1/trends", tags=["Trends"])
+app.include_router(scheduler_router.router, prefix="/api/v1/scheduler", tags=["Scheduler"])

--- a/backend/app/routers/scheduler.py
+++ b/backend/app/routers/scheduler.py
@@ -1,0 +1,18 @@
+"""Scheduler router — exposes scheduler status via REST API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.services.scheduler import get_jobs_status, scheduler
+
+router = APIRouter()
+
+
+@router.get("/status", summary="查询调度器状态及任务列表")
+async def scheduler_status() -> dict:
+    """Return the scheduler running state and a list of all registered jobs."""
+    return {
+        "running": scheduler.running,
+        "jobs": get_jobs_status(),
+    }

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,0 +1,67 @@
+"""APScheduler integration — scheduled jobs for TrendTracker."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+logger = logging.getLogger(__name__)
+
+# Global scheduler instance reused across the application lifecycle.
+scheduler = AsyncIOScheduler()
+
+
+async def collect_trends_job() -> None:
+    """Scheduled job: trigger all registered collectors and persist results.
+
+    In the MVP phase this logs a placeholder message.  Future implementation
+    will iterate :data:`~app.collectors.registry` and save to the database.
+    """
+    logger.info("collect_trends_job: starting trend collection run")
+    from app.collectors import registry
+
+    for platform in registry.list_platforms():
+        try:
+            collector_cls = registry.get(platform)
+            collector = collector_cls()
+            results = await collector.collect()
+            logger.info("collect_trends_job: collected %d records from %s", len(results), platform)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("collect_trends_job: error collecting from %s: %s", platform, exc)
+
+
+def setup_scheduler() -> AsyncIOScheduler:
+    """Register all recurring jobs and return the scheduler (not yet started)."""
+    if scheduler.get_job("collect_trends") is None:
+        scheduler.add_job(
+            collect_trends_job,
+            trigger=IntervalTrigger(hours=1),
+            id="collect_trends",
+            name="Collect trends from all platforms",
+            replace_existing=True,
+        )
+        logger.info("setup_scheduler: registered 'collect_trends' job (every 1 hour)")
+    return scheduler
+
+
+def get_jobs_status() -> list[dict[str, Any]]:
+    """Return a serialisable snapshot of all scheduled jobs."""
+    jobs = []
+    for job in scheduler.get_jobs():
+        try:
+            nrt = job.next_run_time
+            next_run = nrt.isoformat() if nrt else None
+        except AttributeError:
+            next_run = None
+        jobs.append(
+            {
+                "id": job.id,
+                "name": job.name,
+                "next_run_time": next_run,
+                "trigger": str(job.trigger),
+            }
+        )
+    return jobs

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,104 @@
+"""Unit and integration tests for APScheduler integration."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.services.scheduler import collect_trends_job, get_jobs_status, setup_scheduler
+
+
+# ---------------------------------------------------------------------------
+# setup_scheduler
+# ---------------------------------------------------------------------------
+
+
+def test_setup_scheduler_registers_collect_trends_job():
+    sched = setup_scheduler()
+    job = sched.get_job("collect_trends")
+    assert job is not None
+    assert job.id == "collect_trends"
+
+
+def test_setup_scheduler_idempotent():
+    """Calling setup_scheduler twice should not duplicate jobs."""
+    setup_scheduler()
+    setup_scheduler()
+    sched = setup_scheduler()
+    job_ids = [j.id for j in sched.get_jobs()]
+    assert job_ids.count("collect_trends") == 1
+
+
+def test_setup_scheduler_job_trigger_is_interval():
+    from apscheduler.triggers.interval import IntervalTrigger
+
+    sched = setup_scheduler()
+    job = sched.get_job("collect_trends")
+    assert isinstance(job.trigger, IntervalTrigger)
+
+
+# ---------------------------------------------------------------------------
+# get_jobs_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_jobs_status_returns_list():
+    setup_scheduler()
+    status = get_jobs_status()
+    assert isinstance(status, list)
+
+
+def test_get_jobs_status_contains_collect_trends():
+    setup_scheduler()
+    status = get_jobs_status()
+    ids = [j["id"] for j in status]
+    assert "collect_trends" in ids
+
+
+def test_get_jobs_status_record_schema():
+    setup_scheduler()
+    status = get_jobs_status()
+    for job in status:
+        assert "id" in job
+        assert "name" in job
+        assert "trigger" in job
+        assert "next_run_time" in job
+
+
+# ---------------------------------------------------------------------------
+# collect_trends_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_trends_job_runs_without_error():
+    """The job should complete without raising even when the DB is unavailable."""
+    await collect_trends_job()
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/scheduler/status endpoint (integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_status_endpoint():
+    from app.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/v1/scheduler/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "running" in data
+    assert "jobs" in data
+    assert isinstance(data["jobs"], list)
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_still_works():
+    from app.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- Embed AsyncIOScheduler in FastAPI lifespan (start on startup, shutdown gracefully)
- Register collect_trends job with IntervalTrigger(hours=1)
- Add GET /api/v1/scheduler/status endpoint returning running state and job list
- Defensive handling of next_run_time attribute for APScheduler 3.x

## Test plan
- [x] 9 unit + integration tests pass (tests/test_scheduler.py)
- [x] Full suite: 52/52 tests pass
- [x] ruff + black clean

Closes #8