### PR TITLE
feat(frontend): Phase 2 — 前端骨架（页面路由 + 布局 + API层）

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,14 +1,49 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { BarChart3, Brain, Bell, Database } from "lucide-react"
+import { api, type HealthStatus } from "@/lib/api"
 
 export default function DashboardPage() {
+  const [health, setHealth] = useState<HealthStatus | null>(null)
+  const [healthError, setHealthError] = useState(false)
+
+  useEffect(() => {
+    api
+      .health()
+      .then((data) => setHealth(data))
+      .catch(() => setHealthError(true))
+  }, [])
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold">仪表盘</h1>
         <p className="text-muted-foreground mt-1">全网趋势概览</p>
       </div>
+
+      {/* Backend Status */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">后端服务</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-3">
+          {health ? (
+            <>
+              <Badge variant="default" className="bg-green-500 hover:bg-green-500">
+                {health.status === "ok" ? "正常" : health.status}
+              </Badge>
+              <span className="text-xs text-muted-foreground">v{health.version}</span>
+            </>
+          ) : healthError ? (
+            <Badge variant="destructive">离线</Badge>
+          ) : (
+            <span className="text-xs text-muted-foreground">连接中…</span>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Status Cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -20,8 +20,14 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return json.data ?? (json as T)
 }
 
+export interface HealthStatus {
+  status: string
+  version: string
+}
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
     request<T>(path, { method: "POST", body: JSON.stringify(body) }),
+  health: () => request<HealthStatus>("/health"),
 }


### PR DESCRIPTION
## Summary

- 四个页面路由 `/`、`/trends`、`/ai`、`/alerts` 均可访问
- AppSidebar 侧边栏路由高亮（`render` prop 兼容 shadcn v4）
- `lib/api.ts` 封装统一请求，含 `HealthStatus` 类型和 `api.health()`
- Dashboard 调用 `/health` 接口显示后端状态（正常 / 离线 / 连接中）

## Test plan

- [ ] `npm run build` 无报错
- [ ] 访问 `http://localhost:3000/` 可看到仪表盘，后端状态显示正常/离线
- [ ] 访问 `/trends`、`/ai`、`/alerts` 均能渲染占位页面
- [ ] 侧边栏切换页面时对应菜单项高亮

Closes #15