### PR TITLE
feat: 微博热搜真实采集 + 趋势列表页 (#16)

### DIFF
--- a/backend/app/collectors/__init__.py
+++ b/backend/app/collectors/__init__.py
@@ -1,8 +1,9 @@
 from app.collectors.base import BaseCollector
 from app.collectors.registry import CollectorRegistry, registry
+from app.collectors.weibo import WeiboCollector
 from app.collectors.weibo_mock import WeiboMockCollector
 
-# Auto-register bundled collectors
-registry.register(WeiboMockCollector)
+# Auto-register real collectors (WeiboCollector overwrites the mock)
+registry.register(WeiboCollector)
 
-__all__ = ["BaseCollector", "CollectorRegistry", "WeiboMockCollector", "registry"]
+__all__ = ["BaseCollector", "CollectorRegistry", "WeiboCollector", "WeiboMockCollector", "registry"]

--- a/backend/app/collectors/weibo.py
+++ b/backend/app/collectors/weibo.py
@@ -1,0 +1,52 @@
+"""Weibo hot search real collector — uses the public side/hotSearch API."""
+
+from __future__ import annotations
+
+import httpx
+
+from app.collectors.base import BaseCollector
+
+_WEIBO_HOT_SEARCH_URL = "https://weibo.com/ajax/side/hotSearch"
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://weibo.com/",
+    "Accept": "application/json, text/plain, */*",
+}
+
+
+class WeiboCollector(BaseCollector):
+    """Real Weibo hot search collector using the public API (no login required)."""
+
+    platform = "weibo"
+
+    async def collect(self) -> list[dict]:
+        """Fetch Top-50 hot search entries from Weibo public API.
+
+        Returns a list of dicts with standard BaseCollector fields.
+        Raises httpx.HTTPError on network / HTTP failures.
+        """
+        now = self._now()
+        async with httpx.AsyncClient(headers=_HEADERS, timeout=15.0) as client:
+            resp = await client.get(_WEIBO_HOT_SEARCH_URL)
+            resp.raise_for_status()
+            data = resp.json()
+
+        items = data.get("data", {}).get("realtime", [])
+        results = []
+        for item in items[:50]:
+            word = item.get("word", "")
+            results.append(
+                {
+                    "platform": self.platform,
+                    "keyword": word,
+                    "rank": item.get("rank"),
+                    "heat_score": float(item.get("num", 0)),
+                    "url": f"https://s.weibo.com/weibo?q=%23{word}%23",
+                    "collected_at": now,
+                }
+            )
+        return results

--- a/backend/app/routers/collector.py
+++ b/backend/app/routers/collector.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
 from app.schemas.collector import CollectorRunResponse
 from app.services.collector import run_all_collectors
 
@@ -11,7 +13,7 @@ router = APIRouter()
 
 
 @router.post("/run", summary="手动触发全平台数据采集", response_model=CollectorRunResponse)
-async def collector_run() -> CollectorRunResponse:
-    """Manually trigger all registered collectors and return the result."""
-    result = await run_all_collectors()
+async def collector_run(db: AsyncSession = Depends(get_db)) -> CollectorRunResponse:
+    """Manually trigger all registered collectors, persist results, and return summary."""
+    result = await run_all_collectors(db)
     return CollectorRunResponse(**result)

--- a/backend/app/routers/trends.py
+++ b/backend/app/routers/trends.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
 from app.schemas.trends import PlatformsResponse, TrendsListResponse
 from app.services.trends import get_platforms, get_trends
 
@@ -14,9 +16,10 @@ router = APIRouter()
 async def list_trends(
     page: int = Query(default=1, ge=1, description="页码，从 1 开始"),
     page_size: int = Query(default=20, ge=1, le=100, description="每页条数"),
+    db: AsyncSession = Depends(get_db),
 ) -> TrendsListResponse:
-    """Return a paginated list of trend records (mock data in MVP)."""
-    data = get_trends(page=page, page_size=page_size)
+    """Return a paginated list of trend records from the database."""
+    data = await get_trends(db=db, page=page, page_size=page_size)
     return TrendsListResponse(**data)
 
 

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -1,31 +1,55 @@
-"""Collector service — business logic for manual collection runs."""
+"""Collector service — run all collectors and persist results to DB."""
 
 from __future__ import annotations
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.collectors.registry import registry
-from app.collectors.weibo_mock import WeiboMockCollector
-
-# Register built-in collectors if not already registered.
-if WeiboMockCollector.platform not in registry.list_platforms():
-    registry.register(WeiboMockCollector)
+from app.models.platform import Platform
+from app.models.trend import Trend
 
 
-async def run_all_collectors() -> dict:
-    """Run all registered collectors and return aggregated result.
+async def _ensure_platform(db: AsyncSession, slug: str) -> int:
+    """Get or create a platform record; return its id."""
+    result = await db.execute(select(Platform).where(Platform.slug == slug))
+    platform = result.scalar_one_or_none()
+    if platform is None:
+        platform = Platform(name=slug.capitalize(), slug=slug)
+        db.add(platform)
+        await db.flush()
+    return platform.id
+
+
+async def run_all_collectors(db: AsyncSession) -> dict:
+    """Run all registered collectors, persist results to DB, return summary.
 
     Returns a dict with ``status`` and ``records_count``.
-    Business logic only; no DB writes in MVP (mock data).
     """
-    platforms = registry.list_platforms()
     total_records = 0
 
-    for platform in platforms:
-        collector_cls = registry.get(platform)
+    for platform_slug in registry.list_platforms():
+        collector_cls = registry.get(platform_slug)
         collector = collector_cls()
         try:
             records = await collector.collect()
-            total_records += len(records)
+            if records:
+                platform_id = await _ensure_platform(db, platform_slug)
+                for rec in records:
+                    db.add(
+                        Trend(
+                            platform_id=platform_id,
+                            platform=rec["platform"],
+                            keyword=rec["keyword"],
+                            rank=rec.get("rank"),
+                            heat_score=rec.get("heat_score"),
+                            url=rec.get("url"),
+                            collected_at=rec["collected_at"],
+                        )
+                    )
+                total_records += len(records)
         except Exception:  # noqa: BLE001
             pass
 
+    await db.commit()
     return {"status": "ok", "records_count": total_records}

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -1,70 +1,40 @@
-"""Trends service — business logic for trends queries."""
+"""Trends service — DB queries for trend data."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.collectors.registry import registry
-from app.collectors.weibo_mock import WeiboMockCollector
-
-# Register built-in collectors if not already registered.
-if WeiboMockCollector.platform not in registry.list_platforms():
-    registry.register(WeiboMockCollector)
-
-# ---------------------------------------------------------------------------
-# Mock trend data used until real DB persistence is implemented.
-# ---------------------------------------------------------------------------
-
-_MOCK_TRENDS = [
-    {
-        "platform": "weibo",
-        "keyword": "ChatGPT最新版",
-        "rank": 1,
-        "heat_score": 9800.0,
-        "url": "https://weibo.com/hot/1",
-        "collected_at": datetime(2026, 3, 19, 6, 0, 0, tzinfo=UTC),
-    },
-    {
-        "platform": "weibo",
-        "keyword": "春节档电影票房",
-        "rank": 2,
-        "heat_score": 8500.0,
-        "url": "https://weibo.com/hot/2",
-        "collected_at": datetime(2026, 3, 19, 6, 0, 0, tzinfo=UTC),
-    },
-    {
-        "platform": "weibo",
-        "keyword": "A股行情",
-        "rank": 3,
-        "heat_score": 7200.0,
-        "url": "https://weibo.com/hot/3",
-        "collected_at": datetime(2026, 3, 19, 6, 0, 0, tzinfo=UTC),
-    },
-    {
-        "platform": "weibo",
-        "keyword": "世界杯预选赛",
-        "rank": 4,
-        "heat_score": 6100.0,
-        "url": "https://weibo.com/hot/4",
-        "collected_at": datetime(2026, 3, 19, 6, 0, 0, tzinfo=UTC),
-    },
-    {
-        "platform": "weibo",
-        "keyword": "国产大模型发布",
-        "rank": 5,
-        "heat_score": 5500.0,
-        "url": "https://weibo.com/hot/5",
-        "collected_at": datetime(2026, 3, 19, 6, 0, 0, tzinfo=UTC),
-    },
-]
+from app.models.trend import Trend
 
 
-def get_trends(page: int = 1, page_size: int = 20) -> dict:
-    """Return a paginated slice of mock trend data."""
-    total = len(_MOCK_TRENDS)
-    start = (page - 1) * page_size
-    end = start + page_size
-    items = _MOCK_TRENDS[start:end]
+async def get_trends(db: AsyncSession, page: int = 1, page_size: int = 20) -> dict:
+    """Return paginated trends from the database, ordered by collected_at desc then rank."""
+    offset = (page - 1) * page_size
+
+    count_result = await db.execute(select(func.count()).select_from(Trend))
+    total = count_result.scalar_one()
+
+    result = await db.execute(
+        select(Trend)
+        .order_by(Trend.collected_at.desc(), Trend.rank)
+        .offset(offset)
+        .limit(page_size)
+    )
+    trends = result.scalars().all()
+
+    items = [
+        {
+            "platform": t.platform,
+            "keyword": t.keyword,
+            "rank": t.rank,
+            "heat_score": t.heat_score,
+            "url": t.url,
+            "collected_at": t.collected_at,
+        }
+        for t in trends
+    ]
     return {"total": total, "page": page, "page_size": page_size, "items": items}
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "httpx>=0.27",
     "ruff>=0.3",
     "black>=24.0",
+    "aiosqlite>=0.20",
 ]
 
 [tool.black]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared test fixtures for TrendTracker backend tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import app.models  # noqa: F401 — ensure all models are registered on Base.metadata
+from app.collectors.registry import registry
+from app.collectors.weibo_mock import WeiboMockCollector
+from app.database import Base, get_db
+from app.main import app
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture(autouse=True)
+def use_mock_collector():
+    """Replace real WeiboCollector with WeiboMockCollector for all tests."""
+    registry.register(WeiboMockCollector)
+    yield
+    # Restore real collector after each test
+    from app.collectors.weibo import WeiboCollector
+
+    registry.register(WeiboCollector)
+
+
+@pytest.fixture
+async def db_session():
+    """Provide a fresh SQLite in-memory database session for each test."""
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def test_client(db_session: AsyncSession):
+    """Async HTTP test client with DB dependency overridden to use SQLite."""
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from httpx import ASGITransport, AsyncClient
-
-from app.main import app
+from httpx import AsyncClient
 
 # ---------------------------------------------------------------------------
 # POST /api/v1/collector/run
@@ -13,16 +11,14 @@ from app.main import app
 
 
 @pytest.mark.asyncio
-async def test_collector_run_returns_200():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post("/api/v1/collector/run")
+async def test_collector_run_returns_200(test_client: AsyncClient):
+    resp = await test_client.post("/api/v1/collector/run")
     assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_collector_run_response_schema():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post("/api/v1/collector/run")
+async def test_collector_run_response_schema(test_client: AsyncClient):
+    resp = await test_client.post("/api/v1/collector/run")
     data = resp.json()
     assert "status" in data
     assert "records_count" in data
@@ -30,16 +26,14 @@ async def test_collector_run_response_schema():
 
 
 @pytest.mark.asyncio
-async def test_collector_run_status_ok():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post("/api/v1/collector/run")
+async def test_collector_run_status_ok(test_client: AsyncClient):
+    resp = await test_client.post("/api/v1/collector/run")
     assert resp.json()["status"] == "ok"
 
 
 @pytest.mark.asyncio
-async def test_collector_run_records_count_positive():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.post("/api/v1/collector/run")
+async def test_collector_run_records_count_positive(test_client: AsyncClient):
+    resp = await test_client.post("/api/v1/collector/run")
     assert resp.json()["records_count"] > 0
 
 
@@ -49,16 +43,14 @@ async def test_collector_run_records_count_positive():
 
 
 @pytest.mark.asyncio
-async def test_trends_list_returns_200():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends")
+async def test_trends_list_returns_200(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends")
     assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_trends_list_response_schema():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends")
+async def test_trends_list_response_schema(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends")
     data = resp.json()
     assert "total" in data
     assert "page" in data
@@ -68,10 +60,10 @@ async def test_trends_list_response_schema():
 
 
 @pytest.mark.asyncio
-async def test_trends_list_item_schema():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends")
-    items = resp.json()["items"]
+async def test_trends_list_item_schema(test_client: AsyncClient):
+    # Seed data via collector, then check list schema
+    await test_client.post("/api/v1/collector/run")
+    items = (await test_client.get("/api/v1/trends")).json()["items"]
     assert len(items) > 0
     required = {"platform", "keyword", "rank", "heat_score", "url", "collected_at"}
     for item in items:
@@ -79,29 +71,25 @@ async def test_trends_list_item_schema():
 
 
 @pytest.mark.asyncio
-async def test_trends_list_default_pagination():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends")
+async def test_trends_list_default_pagination(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends")
     data = resp.json()
     assert data["page"] == 1
     assert data["page_size"] == 20
 
 
 @pytest.mark.asyncio
-async def test_trends_list_custom_pagination():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends?page=1&page_size=2")
-    data = resp.json()
+async def test_trends_list_custom_pagination(test_client: AsyncClient):
+    await test_client.post("/api/v1/collector/run")
+    data = (await test_client.get("/api/v1/trends?page=1&page_size=2")).json()
     assert data["page"] == 1
     assert data["page_size"] == 2
     assert len(data["items"]) <= 2
 
 
 @pytest.mark.asyncio
-async def test_trends_list_page_out_of_range():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends?page=999&page_size=20")
-    data = resp.json()
+async def test_trends_list_page_out_of_range(test_client: AsyncClient):
+    data = (await test_client.get("/api/v1/trends?page=999&page_size=20")).json()
     assert data["page"] == 999
     assert data["items"] == []
 
@@ -112,23 +100,20 @@ async def test_trends_list_page_out_of_range():
 
 
 @pytest.mark.asyncio
-async def test_trends_platforms_returns_200():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends/platforms")
+async def test_trends_platforms_returns_200(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/platforms")
     assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_trends_platforms_response_schema():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends/platforms")
+async def test_trends_platforms_response_schema(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/platforms")
     data = resp.json()
     assert "platforms" in data
     assert isinstance(data["platforms"], list)
 
 
 @pytest.mark.asyncio
-async def test_trends_platforms_contains_weibo():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/v1/trends/platforms")
+async def test_trends_platforms_contains_weibo(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/platforms")
     assert "weibo" in resp.json()["platforms"]

--- a/backend/tests/test_weibo_collector.py
+++ b/backend/tests/test_weibo_collector.py
@@ -1,0 +1,156 @@
+"""Unit tests for WeiboCollector — real HTTP calls mocked via unittest.mock."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.collectors.weibo import WeiboCollector
+
+_MOCK_WEIBO_RESPONSE = {
+    "ok": 1,
+    "data": {
+        "realtime": [
+            {"word": "话题A", "num": 9876543, "rank": 0},
+            {"word": "话题B", "num": 5432100, "rank": 1},
+            {"word": "话题C", "num": 1234567, "rank": 2},
+        ]
+    },
+}
+
+
+def _make_mock_response(json_data: dict, status_code: int = 200):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_data
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_returns_list():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_item_schema():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    required = {"platform", "keyword", "rank", "heat_score", "url", "collected_at"}
+    for item in results:
+        assert required <= set(item.keys())
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_platform_is_weibo():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    assert all(r["platform"] == "weibo" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_keyword_matches_word():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    words = [r["keyword"] for r in results]
+    assert words == ["话题A", "话题B", "话题C"]
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_heat_score_from_num():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    assert results[0]["heat_score"] == 9876543.0
+    assert results[1]["heat_score"] == 5432100.0
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_collected_at_is_datetime():
+    mock_resp = _make_mock_response(_MOCK_WEIBO_RESPONSE)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    for item in results:
+        assert isinstance(item["collected_at"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_empty_realtime():
+    mock_resp = _make_mock_response({"ok": 1, "data": {"realtime": []}})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_weibo_collector_truncates_at_50():
+    realtime = [{"word": f"话题{i}", "num": i * 1000, "rank": i} for i in range(60)]
+    mock_resp = _make_mock_response({"ok": 1, "data": {"realtime": realtime}})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.collectors.weibo.httpx.AsyncClient", return_value=mock_client):
+        collector = WeiboCollector()
+        results = await collector.collect()
+
+    assert len(results) == 50

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -1,8 +1,203 @@
-export default function TrendsPage() {
+"use client"
+
+import { useEffect, useState } from "react"
+import { TrendingUp, RefreshCw, ExternalLink, Flame } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { api, TrendItem } from "@/lib/api"
+
+const PLATFORM_LABELS: Record<string, string> = {
+  weibo: "微博",
+  google: "Google",
+  tiktok: "TikTok",
+}
+
+function formatHeat(score: number | null): string {
+  if (score === null) return "—"
+  if (score >= 1_000_000) return `${(score / 1_000_000).toFixed(1)}M`
+  if (score >= 1_000) return `${(score / 1_000).toFixed(0)}K`
+  return String(score)
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+}
+
+function TrendRow({ item, index }: { item: TrendItem; index: number }) {
+  const rankDisplay = item.rank !== null ? item.rank + 1 : index + 1
+  const isHot = rankDisplay <= 3
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold">趋势列表</h1>
-      <p className="text-muted-foreground mt-1">Coming soon</p>
+    <div className="flex items-center gap-4 py-3 border-b last:border-0 hover:bg-muted/30 transition-colors px-4">
+      <span
+        className={`w-8 text-center text-sm font-bold shrink-0 ${
+          rankDisplay === 1
+            ? "text-red-500"
+            : rankDisplay === 2
+              ? "text-orange-400"
+              : rankDisplay === 3
+                ? "text-yellow-500"
+                : "text-muted-foreground"
+        }`}
+      >
+        {rankDisplay}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {isHot && <Flame className="w-3.5 h-3.5 text-red-400 shrink-0" />}
+          <span className="font-medium text-sm truncate">{item.keyword}</span>
+        </div>
+        <div className="flex items-center gap-2 mt-0.5">
+          <Badge variant="secondary" className="text-xs py-0 h-4">
+            {PLATFORM_LABELS[item.platform] ?? item.platform}
+          </Badge>
+          <span className="text-xs text-muted-foreground">{formatTime(item.collected_at)}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 shrink-0">
+        <span className="text-sm font-mono text-muted-foreground w-16 text-right">
+          {formatHeat(item.heat_score)}
+        </span>
+        {item.url && (
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TrendRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 py-3 border-b last:border-0 px-4">
+      <Skeleton className="w-8 h-4 shrink-0" />
+      <div className="flex-1 space-y-1.5">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+      <Skeleton className="w-16 h-4" />
+    </div>
+  )
+}
+
+export default function TrendsPage() {
+  const [items, setItems] = useState<TrendItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const pageSize = 50
+
+  const fetchTrends = async (p: number) => {
+    setLoading(true)
+    try {
+      const res = await api.trends.list(p, pageSize)
+      setItems(res.items)
+      setTotal(res.total)
+      setPage(res.page)
+    } catch {
+      // silently ignore — backend may not be running
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchTrends(1)
+  }, [])
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      await api.post("/api/v1/collector/run", {})
+      await fetchTrends(1)
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <TrendingUp className="w-6 h-6" />
+            趋势列表
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            共 {total} 条热词记录
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={refreshing || loading}
+          className="gap-2"
+        >
+          <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} />
+          立即采集
+        </Button>
+      </div>
+
+      {/* Trends Card */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">热词排行</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            Array.from({ length: 10 }).map((_, i) => <TrendRowSkeleton key={i} />)
+          ) : items.length === 0 ? (
+            <div className="py-16 text-center text-muted-foreground">
+              <TrendingUp className="w-12 h-12 mx-auto mb-3 opacity-30" />
+              <p className="text-sm">暂无数据，点击「立即采集」获取热词</p>
+            </div>
+          ) : (
+            items.map((item, i) => <TrendRow key={`${item.platform}-${item.keyword}-${i}`} item={item} index={i} />)
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchTrends(page - 1)}
+            disabled={page <= 1 || loading}
+          >
+            上一页
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {page} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchTrends(page + 1)}
+            disabled={page >= totalPages || loading}
+          >
+            下一页
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -25,9 +25,29 @@ export interface HealthStatus {
   version: string
 }
 
+export interface TrendItem {
+  platform: string
+  keyword: string
+  rank: number | null
+  heat_score: number | null
+  url: string | null
+  collected_at: string
+}
+
+export interface TrendsListResponse {
+  total: number
+  page: number
+  page_size: number
+  items: TrendItem[]
+}
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
     request<T>(path, { method: "POST", body: JSON.stringify(body) }),
   health: () => request<HealthStatus>("/health"),
+  trends: {
+    list: (page = 1, pageSize = 20) =>
+      request<TrendsListResponse>(`/api/v1/trends?page=${page}&page_size=${pageSize}`),
+  },
 }


### PR DESCRIPTION
Closes #16

## Summary
- **WeiboCollector**: 真实调用 `weibo.com/ajax/side/hotSearch` 获取 Top 50 热词，无需登录
- **DB 持久化**: `run_all_collectors()` 采集后写入 `trends` + `platforms` 表（SQLAlchemy async）
- **趋势接口**: `GET /api/v1/trends` 改为从数据库查询（支持分页、按时间降序）
- **前端 /trends 页面**: 热词排行列表，含热度格式化、平台标签、时间、外链跳转、立即采集按钮

## Test plan
- [x] 73 tests pass (`pytest tests/ -v`) — 新增 8 个 WeiboCollector 单元测试（httpx mock）
- [x] Router 集成测试改用 SQLite in-memory + conftest.py fixtures
- [x] `ruff check app/` — no errors
- [x] `black --check app/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)