### PR TITLE
feat(frontend): 仪表盘热力图（ECharts）(#17)

### DIFF
--- a/backend/app/routers/trends.py
+++ b/backend/app/routers/trends.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.trends import PlatformsResponse, TrendsListResponse
-from app.services.trends import get_platforms, get_trends
+from app.schemas.trends import HeatmapResponse, PlatformsResponse, TrendsListResponse
+from app.services.trends import get_heatmap, get_platforms, get_trends
 
 router = APIRouter()
 
@@ -21,6 +21,13 @@ async def list_trends(
     """Return a paginated list of trend records from the database."""
     data = await get_trends(db=db, page=page, page_size=page_size)
     return TrendsListResponse(**data)
+
+
+@router.get("/heatmap", summary="获取热力图数据（最近24小时）", response_model=HeatmapResponse)
+async def trends_heatmap(db: AsyncSession = Depends(get_db)) -> HeatmapResponse:
+    """Return heatmap data grouped by platform × hour for the last 24 hours."""
+    data = await get_heatmap(db=db)
+    return HeatmapResponse(**data)
 
 
 @router.get("/platforms", summary="获取已注册平台列表", response_model=PlatformsResponse)

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -25,3 +25,10 @@ class TrendsListResponse(BaseModel):
 
 class PlatformsResponse(BaseModel):
     platforms: list[str]
+
+
+class HeatmapResponse(BaseModel):
+    platforms: list[str]
+    time_slots: list[str]
+    data: list[list[float]]
+    max_heat: float

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -41,3 +43,64 @@ async def get_trends(db: AsyncSession, page: int = 1, page_size: int = 20) -> di
 def get_platforms() -> list[str]:
     """Return all registered platform slugs."""
     return registry.list_platforms()
+
+
+async def get_heatmap(db: AsyncSession) -> dict:
+    """Build heatmap data for the last 24 hours, grouped by platform × hour.
+
+    Returns:
+        platforms: sorted list of platform slugs found in data
+        time_slots: 24 hour labels ("HH:MM") from oldest to newest
+        data: list of [platform_idx, slot_idx, max_heat_score]
+        max_heat: global maximum heat score (for visualMap scaling)
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)  # naive UTC, matches DB storage
+    since = now - timedelta(hours=24)
+
+    # Generate 24 ordered time slots (oldest → newest)
+    slots: list[datetime] = [
+        (now - timedelta(hours=23 - i)).replace(minute=0, second=0, microsecond=0)
+        for i in range(24)
+    ]
+    slot_index: dict[str, int] = {s.strftime("%Y-%m-%d %H"): i for i, s in enumerate(slots)}
+
+    result = await db.execute(
+        select(Trend.platform, Trend.collected_at, Trend.heat_score).where(
+            Trend.collected_at >= since
+        )
+    )
+    rows = result.all()
+
+    # Collect unique platforms (sorted for stable ordering)
+    platforms = sorted({row.platform for row in rows if row.platform})
+    platform_index = {p: i for i, p in enumerate(platforms)}
+
+    # Aggregate: cell[platform_idx][slot_idx] = max heat_score
+    cells: dict[tuple[int, int], float] = {}
+    for row in rows:
+        if row.heat_score is None:
+            continue
+        p_idx = platform_index.get(row.platform)
+        if p_idx is None:
+            continue
+        # Strip timezone if present (DB returns naive datetimes)
+        collected = row.collected_at
+        if hasattr(collected, "tzinfo") and collected.tzinfo is not None:
+            collected = collected.replace(tzinfo=None)
+        hour_key = collected.strftime("%Y-%m-%d %H")
+        s_idx = slot_index.get(hour_key)
+        if s_idx is None:
+            continue
+        key = (p_idx, s_idx)
+        cells[key] = max(cells.get(key, 0.0), float(row.heat_score))
+
+    data = [[float(p), float(s), v] for (p, s), v in cells.items()]
+    max_heat = max(cells.values(), default=0.0)
+    time_labels = [s.strftime("%H:%M") for s in slots]
+
+    return {
+        "platforms": platforms,
+        "time_slots": time_labels,
+        "data": data,
+        "max_heat": max_heat,
+    }

--- a/backend/tests/test_heatmap.py
+++ b/backend/tests/test_heatmap.py
@@ -1,0 +1,96 @@
+"""Tests for GET /api/v1/trends/heatmap endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trend import Trend
+
+
+async def _seed_trends(db: AsyncSession, count: int = 5) -> None:
+    """Insert mock trend rows into the test DB."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    for i in range(count):
+        db.add(
+            Trend(
+                platform="weibo",
+                keyword=f"话题{i}",
+                rank=i,
+                heat_score=float((count - i) * 1000),
+                url=None,
+                collected_at=now - timedelta(minutes=i * 10),
+            )
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_heatmap_returns_200(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/heatmap")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_heatmap_response_schema(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/heatmap")
+    data = resp.json()
+    assert "platforms" in data
+    assert "time_slots" in data
+    assert "data" in data
+    assert "max_heat" in data
+    assert isinstance(data["platforms"], list)
+    assert isinstance(data["time_slots"], list)
+    assert isinstance(data["data"], list)
+    assert isinstance(data["max_heat"], float)
+
+
+@pytest.mark.asyncio
+async def test_heatmap_empty_db(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/heatmap")
+    data = resp.json()
+    assert data["platforms"] == []
+    assert len(data["time_slots"]) == 24
+    assert data["data"] == []
+    assert data["max_heat"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_heatmap_time_slots_count(test_client: AsyncClient):
+    data = (await test_client.get("/api/v1/trends/heatmap")).json()
+    assert len(data["time_slots"]) == 24
+
+
+@pytest.mark.asyncio
+async def test_heatmap_with_data(test_client: AsyncClient, db_session: AsyncSession):
+    await _seed_trends(db_session)
+    data = (await test_client.get("/api/v1/trends/heatmap")).json()
+    assert "weibo" in data["platforms"]
+    assert len(data["data"]) > 0
+    assert data["max_heat"] > 0
+
+
+@pytest.mark.asyncio
+async def test_heatmap_data_items_have_three_elements(
+    test_client: AsyncClient, db_session: AsyncSession
+):
+    await _seed_trends(db_session)
+    items = (await test_client.get("/api/v1/trends/heatmap")).json()["data"]
+    for item in items:
+        assert len(item) == 3
+
+
+@pytest.mark.asyncio
+async def test_heatmap_excludes_old_data(test_client: AsyncClient, db_session: AsyncSession):
+    # Insert a trend older than 24 hours — should not appear
+    old_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=25)
+    db_session.add(
+        Trend(platform="weibo", keyword="旧话题", rank=1, heat_score=9999.0, collected_at=old_time)
+    )
+    await db_session.commit()
+    data = (await test_client.get("/api/v1/trends/heatmap")).json()
+    assert data["platforms"] == []
+    assert data["data"] == []

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,18 +3,28 @@
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
 import { BarChart3, Brain, Bell, Database } from "lucide-react"
-import { api, type HealthStatus } from "@/lib/api"
+import { api, type HealthStatus, type HeatmapResponse } from "@/lib/api"
+import { HeatmapChart } from "@/components/HeatmapChart"
 
 export default function DashboardPage() {
   const [health, setHealth] = useState<HealthStatus | null>(null)
   const [healthError, setHealthError] = useState(false)
+  const [heatmap, setHeatmap] = useState<HeatmapResponse | null>(null)
+  const [heatmapLoading, setHeatmapLoading] = useState(true)
 
   useEffect(() => {
     api
       .health()
       .then((data) => setHealth(data))
       .catch(() => setHealthError(true))
+
+    api.trends
+      .heatmap()
+      .then((data) => setHeatmap(data))
+      .catch(() => setHeatmap(null))
+      .finally(() => setHeatmapLoading(false))
   }, [])
 
   return (
@@ -91,6 +101,24 @@ export default function DashboardPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Heatmap */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">热度分布（近24小时）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {heatmapLoading ? (
+            <Skeleton className="w-full h-80" />
+          ) : heatmap && heatmap.platforms.length > 0 ? (
+            <HeatmapChart data={heatmap} />
+          ) : (
+            <div className="h-80 flex items-center justify-center text-muted-foreground text-sm">
+              暂无数据，请先在趋势列表页点击「立即采集」
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Platform Status */}
       <Card>

--- a/frontend/components/HeatmapChart.tsx
+++ b/frontend/components/HeatmapChart.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import type { HeatmapResponse } from "@/lib/api"
+
+const PLATFORM_LABELS: Record<string, string> = {
+  weibo: "微博",
+  google: "Google",
+  tiktok: "TikTok",
+  baidu: "百度",
+}
+
+interface Props {
+  data: HeatmapResponse
+}
+
+export function HeatmapChart({ data }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chartRef = useRef<any>(null)
+
+  useEffect(() => {
+    let chart: typeof chartRef.current = null
+
+    async function init() {
+      if (!containerRef.current) return
+      const echarts = await import("echarts")
+      chart = echarts.init(containerRef.current, undefined, { renderer: "canvas" })
+      chartRef.current = chart
+
+      const platformLabels = data.platforms.map((p) => PLATFORM_LABELS[p] ?? p)
+
+      const option = {
+        tooltip: {
+          position: "top",
+          formatter: (params: { data: number[] }) => {
+            const [pIdx, sIdx, value] = params.data
+            const platform = platformLabels[pIdx] ?? String(pIdx)
+            const slot = data.time_slots[sIdx] ?? String(sIdx)
+            const heat =
+              value >= 1_000_000
+                ? `${(value / 1_000_000).toFixed(1)}M`
+                : value >= 1_000
+                  ? `${(value / 1_000).toFixed(0)}K`
+                  : String(value)
+            return `${platform} · ${slot}<br/>热度: <b>${heat}</b>`
+          },
+        },
+        grid: { top: 20, right: 20, bottom: 60, left: 60 },
+        xAxis: {
+          type: "category",
+          data: platformLabels,
+          splitArea: { show: true },
+          axisLabel: { fontSize: 12 },
+        },
+        yAxis: {
+          type: "category",
+          data: data.time_slots,
+          splitArea: { show: true },
+          axisLabel: { fontSize: 11 },
+        },
+        visualMap: {
+          min: 0,
+          max: data.max_heat || 1,
+          calculable: true,
+          orient: "horizontal",
+          left: "center",
+          bottom: 0,
+          inRange: { color: ["#e0f2fe", "#0369a1"] },
+          textStyle: { fontSize: 11 },
+        },
+        series: [
+          {
+            type: "heatmap",
+            data: data.data,
+            label: { show: false },
+            emphasis: {
+              itemStyle: { shadowBlur: 8, shadowColor: "rgba(0,0,0,0.3)" },
+            },
+          },
+        ],
+      }
+
+      chart.setOption(option)
+    }
+
+    init()
+
+    const observer = new ResizeObserver(() => chartRef.current?.resize())
+    if (containerRef.current) observer.observe(containerRef.current)
+
+    return () => {
+      observer.disconnect()
+      chart?.dispose()
+    }
+  }, [data])
+
+  return <div ref={containerRef} style={{ width: "100%", height: 320 }} />
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -41,6 +41,13 @@ export interface TrendsListResponse {
   items: TrendItem[]
 }
 
+export interface HeatmapResponse {
+  platforms: string[]
+  time_slots: string[]
+  data: number[][]
+  max_heat: number
+}
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
@@ -49,5 +56,6 @@ export const api = {
   trends: {
     list: (page = 1, pageSize = 20) =>
       request<TrendsListResponse>(`/api/v1/trends?page=${page}&page_size=${pageSize}`),
+    heatmap: () => request<HeatmapResponse>("/api/v1/trends/heatmap"),
   },
 }


### PR DESCRIPTION
Closes #17

## Summary
- 新增 `GET /api/v1/trends/heatmap`：最近24小时按平台 × 小时聚合最大热度，返回 ECharts 格式数据
- `HeatmapChart` 组件：纯 ECharts（动态 import 避免 SSR 问题），ResizeObserver 响应式，tooltip 显示平台/时间/热度
- Dashboard 页嵌入热力图，含骨架屏加载态和空数据提示

## Test plan
- [x] `pytest tests/test_heatmap.py` — 7 tests pass（含空DB、旧数据过滤、schema验证）
- [x] `ruff check app/` + `black --check app/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)