### PR TITLE
feat(backend): 收敛评分算法 + /trends/top 接口 (#18)

### DIFF
--- a/backend/app/routers/trends.py
+++ b/backend/app/routers/trends.py
@@ -1,4 +1,4 @@
-"""Trends router — trend list and platform registry endpoints."""
+"""Trends router — trend list, top trends, heatmap, and platform registry endpoints."""
 
 from __future__ import annotations
 
@@ -6,21 +6,36 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.trends import HeatmapResponse, PlatformsResponse, TrendsListResponse
-from app.services.trends import get_heatmap, get_platforms, get_trends
+from app.schemas.trends import (
+    HeatmapResponse,
+    PlatformsResponse,
+    TopTrendsResponse,
+    TrendsListResponse,
+)
+from app.services.trends import get_heatmap, get_platforms, get_top_trends, get_trends
 
 router = APIRouter()
 
 
-@router.get("", summary="获取趋势列表（分页）", response_model=TrendsListResponse)
+@router.get("", summary="获取趋势列表（分页，含收敛评分）", response_model=TrendsListResponse)
 async def list_trends(
     page: int = Query(default=1, ge=1, description="页码，从 1 开始"),
     page_size: int = Query(default=20, ge=1, le=100, description="每页条数"),
     db: AsyncSession = Depends(get_db),
 ) -> TrendsListResponse:
-    """Return a paginated list of trend records from the database."""
+    """Return a paginated list of trend records with convergence_score."""
     data = await get_trends(db=db, page=page, page_size=page_size)
     return TrendsListResponse(**data)
+
+
+@router.get("/top", summary="按收敛评分排序的 Top 20 趋势", response_model=TopTrendsResponse)
+async def top_trends(
+    limit: int = Query(default=20, ge=1, le=100, description="返回条数"),
+    db: AsyncSession = Depends(get_db),
+) -> TopTrendsResponse:
+    """Return top trending keywords ranked by convergence score (last 24 hours)."""
+    items = await get_top_trends(db=db, limit=limit)
+    return TopTrendsResponse(items=items)
 
 
 @router.get("/heatmap", summary="获取热力图数据（最近24小时）", response_model=HeatmapResponse)

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -14,6 +14,19 @@ class TrendItem(BaseModel):
     heat_score: float | None
     url: str | None
     collected_at: datetime
+    convergence_score: float
+
+
+class TopTrendItem(BaseModel):
+    keyword: str
+    platforms: list[str]
+    max_heat_score: float | None
+    latest_collected_at: datetime
+    convergence_score: float
+
+
+class TopTrendsResponse(BaseModel):
+    items: list[TopTrendItem]
 
 
 class TrendsListResponse(BaseModel):

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -1,7 +1,8 @@
-"""Trends service — DB queries for trend data."""
+"""Trends service — DB queries and convergence scoring for trend data."""
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, select
@@ -10,13 +11,79 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.collectors.registry import registry
 from app.models.trend import Trend
 
+# ---------------------------------------------------------------------------
+# Convergence score — pure function, no I/O
+# ---------------------------------------------------------------------------
+
+
+def compute_convergence_score(
+    heat_score: float | None,
+    rank: int | None,
+    platform_count: int,
+    age_hours: float,
+    max_heat: float,
+) -> float:
+    """Compute a convergence score in the range [0, 100].
+
+    Formula (weighted sum, then exponential recency decay):
+    - heat_component  (50%): heat_score / max_heat * 100
+    - rank_component  (30%): linear from rank 1 (100) to rank 50 (0)
+    - platform_component (20%): each additional platform beyond the first adds score
+
+    Recency decay: half-life of 12 hours — score halves every 12 hours of age.
+    """
+    # Heat component
+    if heat_score and max_heat > 0:
+        heat_component = min(100.0, heat_score / max_heat * 100)
+    else:
+        heat_component = 0.0
+
+    # Rank component (rank is 0-based from Weibo; treat as 1-based for scoring)
+    if rank is not None:
+        effective_rank = rank + 1 if rank >= 0 else rank
+        rank_component = max(0.0, (50 - effective_rank) / 50 * 100)
+    else:
+        rank_component = 0.0
+
+    # Platform component: 0 extra platforms = 0, 4+ extra = 100
+    platform_component = min(100.0, (platform_count - 1) / 4 * 100)
+
+    raw = heat_component * 0.5 + rank_component * 0.3 + platform_component * 0.2
+
+    # Recency decay: half-life 12h
+    decay = math.exp(-age_hours * math.log(2) / 12)
+
+    return round(min(100.0, max(0.0, raw * decay)), 2)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_naive_utc(dt: datetime) -> datetime:
+    """Strip timezone info from a datetime (DB stores naive UTC)."""
+    if dt.tzinfo is not None:
+        return dt.replace(tzinfo=None)
+    return dt
+
+
+# ---------------------------------------------------------------------------
+# Service functions
+# ---------------------------------------------------------------------------
+
 
 async def get_trends(db: AsyncSession, page: int = 1, page_size: int = 20) -> dict:
-    """Return paginated trends from the database, ordered by collected_at desc then rank."""
+    """Return paginated trends with convergence_score, ordered by collected_at desc."""
     offset = (page - 1) * page_size
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     count_result = await db.execute(select(func.count()).select_from(Trend))
     total = count_result.scalar_one()
+
+    # Global max heat for normalization
+    max_result = await db.execute(select(func.max(Trend.heat_score)))
+    max_heat = float(max_result.scalar_one() or 0.0)
 
     result = await db.execute(
         select(Trend)
@@ -26,18 +93,93 @@ async def get_trends(db: AsyncSession, page: int = 1, page_size: int = 20) -> di
     )
     trends = result.scalars().all()
 
-    items = [
-        {
-            "platform": t.platform,
-            "keyword": t.keyword,
-            "rank": t.rank,
-            "heat_score": t.heat_score,
-            "url": t.url,
-            "collected_at": t.collected_at,
-        }
-        for t in trends
-    ]
+    items = []
+    for t in trends:
+        collected = _to_naive_utc(t.collected_at)
+        age_hours = max(0.0, (now - collected).total_seconds() / 3600)
+        score = compute_convergence_score(
+            heat_score=t.heat_score,
+            rank=t.rank,
+            platform_count=1,  # per-row; cross-platform used in /top
+            age_hours=age_hours,
+            max_heat=max_heat,
+        )
+        items.append(
+            {
+                "platform": t.platform,
+                "keyword": t.keyword,
+                "rank": t.rank,
+                "heat_score": t.heat_score,
+                "url": t.url,
+                "collected_at": t.collected_at,
+                "convergence_score": score,
+            }
+        )
     return {"total": total, "page": page, "page_size": page_size, "items": items}
+
+
+async def get_top_trends(db: AsyncSession, limit: int = 20) -> list[dict]:
+    """Return top-N keywords by convergence_score over the last 24 hours.
+
+    Aggregates by keyword across platforms, computes full convergence_score
+    including cross-platform factor.
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    since = now - timedelta(hours=24)
+
+    result = await db.execute(
+        select(Trend).where(Trend.collected_at >= since).order_by(Trend.collected_at.desc())
+    )
+    rows = result.scalars().all()
+
+    # Global max heat for normalization
+    max_heat = max((r.heat_score for r in rows if r.heat_score is not None), default=0.0)
+
+    # Aggregate by keyword: collect platforms, best rank, max heat, latest time
+    keyword_data: dict[str, dict] = {}
+    for row in rows:
+        kw = row.keyword
+        if kw not in keyword_data:
+            keyword_data[kw] = {
+                "platforms": set(),
+                "best_rank": row.rank,
+                "max_heat": row.heat_score or 0.0,
+                "latest": _to_naive_utc(row.collected_at),
+                "url": row.url,
+            }
+        entry = keyword_data[kw]
+        entry["platforms"].add(row.platform)
+        if row.rank is not None and (entry["best_rank"] is None or row.rank < entry["best_rank"]):
+            entry["best_rank"] = row.rank
+        if row.heat_score and row.heat_score > entry["max_heat"]:
+            entry["max_heat"] = row.heat_score
+        latest = _to_naive_utc(row.collected_at)
+        if latest > entry["latest"]:
+            entry["latest"] = latest
+
+    # Score each keyword
+    scored = []
+    for kw, entry in keyword_data.items():
+        age_hours = max(0.0, (now - entry["latest"]).total_seconds() / 3600)
+        score = compute_convergence_score(
+            heat_score=entry["max_heat"],
+            rank=entry["best_rank"],
+            platform_count=len(entry["platforms"]),
+            age_hours=age_hours,
+            max_heat=max_heat,
+        )
+        scored.append(
+            {
+                "keyword": kw,
+                "platforms": sorted(entry["platforms"]),
+                "max_heat_score": entry["max_heat"],
+                "latest_collected_at": entry["latest"],
+                "convergence_score": score,
+            }
+        )
+
+    scored.sort(key=lambda x: x["convergence_score"], reverse=True)
+    return scored[:limit]
 
 
 def get_platforms() -> list[str]:
@@ -46,18 +188,10 @@ def get_platforms() -> list[str]:
 
 
 async def get_heatmap(db: AsyncSession) -> dict:
-    """Build heatmap data for the last 24 hours, grouped by platform × hour.
-
-    Returns:
-        platforms: sorted list of platform slugs found in data
-        time_slots: 24 hour labels ("HH:MM") from oldest to newest
-        data: list of [platform_idx, slot_idx, max_heat_score]
-        max_heat: global maximum heat score (for visualMap scaling)
-    """
-    now = datetime.now(timezone.utc).replace(tzinfo=None)  # naive UTC, matches DB storage
+    """Build heatmap data for the last 24 hours, grouped by platform × hour."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     since = now - timedelta(hours=24)
 
-    # Generate 24 ordered time slots (oldest → newest)
     slots: list[datetime] = [
         (now - timedelta(hours=23 - i)).replace(minute=0, second=0, microsecond=0)
         for i in range(24)
@@ -71,11 +205,9 @@ async def get_heatmap(db: AsyncSession) -> dict:
     )
     rows = result.all()
 
-    # Collect unique platforms (sorted for stable ordering)
     platforms = sorted({row.platform for row in rows if row.platform})
     platform_index = {p: i for i, p in enumerate(platforms)}
 
-    # Aggregate: cell[platform_idx][slot_idx] = max heat_score
     cells: dict[tuple[int, int], float] = {}
     for row in rows:
         if row.heat_score is None:
@@ -83,10 +215,7 @@ async def get_heatmap(db: AsyncSession) -> dict:
         p_idx = platform_index.get(row.platform)
         if p_idx is None:
             continue
-        # Strip timezone if present (DB returns naive datetimes)
-        collected = row.collected_at
-        if hasattr(collected, "tzinfo") and collected.tzinfo is not None:
-            collected = collected.replace(tzinfo=None)
+        collected = _to_naive_utc(row.collected_at)
         hour_key = collected.strftime("%Y-%m-%d %H")
         s_idx = slot_index.get(hour_key)
         if s_idx is None:

--- a/backend/tests/test_convergence.py
+++ b/backend/tests/test_convergence.py
@@ -1,0 +1,183 @@
+"""Tests for convergence score algorithm and /trends/top endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trend import Trend
+from app.services.trends import compute_convergence_score
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: compute_convergence_score (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_score_is_between_0_and_100():
+    score = compute_convergence_score(
+        heat_score=5000.0, rank=0, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    assert 0.0 <= score <= 100.0
+
+
+def test_rank_1_scores_higher_than_rank_50():
+    score_top = compute_convergence_score(
+        heat_score=5000.0, rank=0, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    score_bottom = compute_convergence_score(
+        heat_score=5000.0, rank=49, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    assert score_top > score_bottom
+
+
+def test_higher_heat_scores_higher():
+    score_high = compute_convergence_score(
+        heat_score=9000.0, rank=5, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    score_low = compute_convergence_score(
+        heat_score=1000.0, rank=5, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    assert score_high > score_low
+
+
+def test_more_platforms_scores_higher():
+    score_single = compute_convergence_score(
+        heat_score=5000.0, rank=5, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    score_multi = compute_convergence_score(
+        heat_score=5000.0, rank=5, platform_count=3, age_hours=0.0, max_heat=10000.0
+    )
+    assert score_multi > score_single
+
+
+def test_older_trend_decays():
+    score_fresh = compute_convergence_score(
+        heat_score=5000.0, rank=5, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    score_old = compute_convergence_score(
+        heat_score=5000.0, rank=5, platform_count=1, age_hours=24.0, max_heat=10000.0
+    )
+    assert score_fresh > score_old
+
+
+def test_12h_old_trend_roughly_half_score():
+    score_fresh = compute_convergence_score(
+        heat_score=10000.0, rank=0, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    score_12h = compute_convergence_score(
+        heat_score=10000.0, rank=0, platform_count=1, age_hours=12.0, max_heat=10000.0
+    )
+    # After 12h (one half-life), score should be roughly half
+    assert abs(score_12h - score_fresh / 2) < 5.0
+
+
+def test_none_heat_score_does_not_crash():
+    score = compute_convergence_score(
+        heat_score=None, rank=1, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    assert 0.0 <= score <= 100.0
+
+
+def test_none_rank_does_not_crash():
+    score = compute_convergence_score(
+        heat_score=5000.0, rank=None, platform_count=1, age_hours=0.0, max_heat=10000.0
+    )
+    assert 0.0 <= score <= 100.0
+
+
+def test_zero_max_heat_returns_zero_or_low():
+    score = compute_convergence_score(
+        heat_score=5000.0, rank=None, platform_count=1, age_hours=0.0, max_heat=0.0
+    )
+    assert 0.0 <= score <= 100.0
+
+
+def test_score_capped_at_100():
+    score = compute_convergence_score(
+        heat_score=10000.0, rank=0, platform_count=5, age_hours=0.0, max_heat=10000.0
+    )
+    assert score <= 100.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: GET /api/v1/trends and /api/v1/trends/top
+# ---------------------------------------------------------------------------
+
+
+async def _seed(db: AsyncSession, keyword: str, platform: str, rank: int, heat: float) -> None:
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.add(Trend(platform=platform, keyword=keyword, rank=rank, heat_score=heat, collected_at=now))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_trends_list_includes_convergence_score(test_client: AsyncClient, db_session: AsyncSession):
+    await _seed(db_session, "热词A", "weibo", 0, 9000.0)
+    data = (await test_client.get("/api/v1/trends")).json()
+    for item in data["items"]:
+        assert "convergence_score" in item
+        assert isinstance(item["convergence_score"], float)
+        assert 0.0 <= item["convergence_score"] <= 100.0
+
+
+@pytest.mark.asyncio
+async def test_top_trends_returns_200(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/trends/top")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_top_trends_response_schema(test_client: AsyncClient):
+    data = (await test_client.get("/api/v1/trends/top")).json()
+    assert "items" in data
+    assert isinstance(data["items"], list)
+
+
+@pytest.mark.asyncio
+async def test_top_trends_item_schema(test_client: AsyncClient, db_session: AsyncSession):
+    await _seed(db_session, "热词A", "weibo", 0, 9000.0)
+    items = (await test_client.get("/api/v1/trends/top")).json()["items"]
+    assert len(items) > 0
+    required = {"keyword", "platforms", "max_heat_score", "latest_collected_at", "convergence_score"}
+    for item in items:
+        assert required <= set(item.keys())
+
+
+@pytest.mark.asyncio
+async def test_top_trends_sorted_descending(test_client: AsyncClient, db_session: AsyncSession):
+    await _seed(db_session, "热词High", "weibo", 0, 9000.0)
+    await _seed(db_session, "热词Low", "weibo", 49, 100.0)
+    items = (await test_client.get("/api/v1/trends/top")).json()["items"]
+    scores = [item["convergence_score"] for item in items]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_top_trends_merges_cross_platform(test_client: AsyncClient, db_session: AsyncSession):
+    await _seed(db_session, "爆款词", "weibo", 0, 9000.0)
+    await _seed(db_session, "爆款词", "google", 1, 8000.0)
+    items = (await test_client.get("/api/v1/trends/top")).json()["items"]
+    match = next((i for i in items if i["keyword"] == "爆款词"), None)
+    assert match is not None
+    assert len(match["platforms"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_top_trends_excludes_old_data(test_client: AsyncClient, db_session: AsyncSession):
+    old_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=25)
+    db_session.add(Trend(platform="weibo", keyword="过时词", rank=1, heat_score=9000.0, collected_at=old_time))
+    await db_session.commit()
+    items = (await test_client.get("/api/v1/trends/top")).json()["items"]
+    assert not any(i["keyword"] == "过时词" for i in items)
+
+
+@pytest.mark.asyncio
+async def test_top_trends_respects_limit(test_client: AsyncClient, db_session: AsyncSession):
+    for i in range(10):
+        await _seed(db_session, f"词{i}", "weibo", i, float((10 - i) * 1000))
+    items = (await test_client.get("/api/v1/trends/top?limit=3")).json()["items"]
+    assert len(items) <= 3


### PR DESCRIPTION
Closes #18

## Summary
- **`compute_convergence_score()`** 纯函数：热度分量(50%) + 排名分量(30%) + 跨平台分量(20%)，12小时半衰期时效衰减，输出 0–100 分
- **`GET /api/v1/trends`** 新增 `convergence_score` 字段
- **`GET /api/v1/trends/top`** 新接口：近24小时数据按关键词跨平台聚合，按收敛评分降序，支持 `limit` 参数

## Test plan
- [x] 10 个算法单元测试（边界值、rank/heat/platform 影响、时效衰减半衰期验证）
- [x] 8 个接口集成测试（schema、排序、跨平台合并、旧数据过滤、limit 参数）
- [x] 全套 98 tests pass
- [x] ruff + black 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)