### PR TITLE
chore(ci): add pytest to backend CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   backend:
-    name: Backend (lint + format)
+    name: Backend (lint + format + test)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -23,14 +23,17 @@ jobs:
           cache: "pip"
           cache-dependency-path: backend/pyproject.toml
 
-      - name: Install lint tools
-        run: pip install ruff black
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
 
       - name: Lint (ruff)
         run: ruff check app/
 
       - name: Format check (black)
         run: black --check app/
+
+      - name: Test (pytest)
+        run: pytest tests/ -v --cov=app --cov-report=term-missing
 
   frontend:
     name: Frontend (lint + typecheck + build)


### PR DESCRIPTION
## Summary
- Backend CI job 新增 `pytest tests/ -v --cov=app` 步骤
- 将 `pip install ruff black` 改为 `pip install -e ".[dev]"` 以安装完整测试依赖（包含 aiosqlite、pytest-asyncio 等）
- 测试使用 SQLite in-memory（conftest.py），无需 MySQL service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)