### PR TITLE
feat(backend): AI keyword analysis — MiniMax real API + /ai/analyze endpoint (#19)

### DIFF
--- a/backend/app/ai/minimax_provider.py
+++ b/backend/app/ai/minimax_provider.py
@@ -1,21 +1,33 @@
-"""MiniMax LLM provider stub — does not call the real API in this version."""
+"""MiniMax LLM provider — real ChatCompletion V2 API calls."""
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
+
+import httpx
 
 from app.ai.base import AnalyzeResponse, BaseLLMProvider, ChatMessage, ChatResponse
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.minimax.chat/v1/text/chatcompletion_v2"
+
+_ANALYZE_SYSTEM_PROMPT = (
+    "你是一个商业趋势分析专家。分析用户给出的热门关键词，"
+    "严格以如下 JSON 格式返回（不要有任何额外文字）：\n"
+    "{\n"
+    '  "business_insight": "商业建议，100字以内",\n'
+    '  "sentiment": "positive 或 negative 或 neutral 三者之一",\n'
+    '  "related_keywords": ["词1", "词2", "词3", "词4", "词5"]\n'
+    "}"
+)
+
 
 class MiniMaxProvider(BaseLLMProvider):
-    """Stub implementation of the MiniMax LLM provider.
-
-    In the MVP phase this class returns deterministic placeholder responses so
-    that the rest of the application can be developed and tested without live
-    API credentials.  Replace the method bodies with real ``httpx`` calls once
-    you are ready to connect to the MiniMax API.
-    """
+    """MiniMax LLM provider using ChatCompletion V2 API."""
 
     provider_name = "minimax"
 
@@ -24,18 +36,26 @@ class MiniMaxProvider(BaseLLMProvider):
         self.group_id = settings.minimax_group_id
         self.model = "abab6.5s-chat"
 
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
     async def chat(self, messages: list[ChatMessage], **kwargs: Any) -> ChatResponse:
-        """Return a stub chat reply (no real API call)."""
-        last_user = next(
-            (m.content for m in reversed(messages) if m.role == "user"),
-            "",
-        )
-        stub_content = f"[MiniMax stub] Received: {last_user[:80]}"
-        return ChatResponse(
-            content=stub_content,
-            model=self.model,
-            usage={"prompt_tokens": 0, "completion_tokens": 0},
-        )
+        """Send messages to MiniMax ChatCompletion V2 and return the reply."""
+        payload = {
+            "model": self.model,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(_API_URL, headers=self._headers(), json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+        content = data["choices"][0]["message"]["content"]
+        usage = data.get("usage", {})
+        return ChatResponse(content=content, model=self.model, usage=usage)
 
     async def analyze(
         self,
@@ -44,14 +64,54 @@ class MiniMaxProvider(BaseLLMProvider):
         insight_type: str = "business",
         **kwargs: Any,
     ) -> AnalyzeResponse:
-        """Return a stub analysis (no real API call)."""
-        stub_content = (
-            f"[MiniMax stub] Analysis for '{keyword}' "
-            f"(type={insight_type}): This is a placeholder insight. "
-            "Connect to the real MiniMax API to obtain genuine results."
-        )
+        """Analyze a trend keyword; returns business_insight, sentiment, related_keywords."""
+        user_content = f"请分析热门词：{keyword}"
+        if context:
+            user_content += f"\n背景信息：{context}"
+
+        messages = [
+            ChatMessage(role="system", content=_ANALYZE_SYSTEM_PROMPT),
+            ChatMessage(role="user", content=user_content),
+        ]
+        payload = {
+            "model": self.model,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(_API_URL, headers=self._headers(), json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+        raw_content = data["choices"][0]["message"]["content"]
+        usage = data.get("usage", {})
+
+        # Parse structured JSON from the model response
+        try:
+            parsed = json.loads(raw_content)
+        except json.JSONDecodeError:
+            logger.warning("MiniMax response was not valid JSON, storing raw content")
+            parsed = {
+                "business_insight": raw_content,
+                "sentiment": "neutral",
+                "related_keywords": [],
+            }
+
+        # Normalise fields
+        sentiment = parsed.get("sentiment", "neutral")
+        if sentiment not in {"positive", "negative", "neutral"}:
+            sentiment = "neutral"
+        related = parsed.get("related_keywords", [])
+        if not isinstance(related, list):
+            related = []
+
+        structured = {
+            "business_insight": parsed.get("business_insight", ""),
+            "sentiment": sentiment,
+            "related_keywords": related[:5],
+        }
         return AnalyzeResponse(
             insight_type=insight_type,
-            content=stub_content,
+            content=json.dumps(structured, ensure_ascii=False),
             model=self.model,
+            extra={"usage": usage},
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.routers import ai as ai_router
 from app.routers import collector as collector_router
 from app.routers import scheduler as scheduler_router
 from app.routers import trends as trends_router
@@ -47,3 +48,4 @@ async def health():
 app.include_router(scheduler_router.router, prefix="/api/v1/scheduler", tags=["Scheduler"])
 app.include_router(collector_router.router, prefix="/api/v1/collector", tags=["Collector"])
 app.include_router(trends_router.router, prefix="/api/v1/trends", tags=["Trends"])
+app.include_router(ai_router.router, prefix="/api/v1/ai", tags=["AI"])

--- a/backend/app/models/ai_insight.py
+++ b/backend/app/models/ai_insight.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -15,7 +15,10 @@ if TYPE_CHECKING:
 class AIInsight(Base):
     __tablename__ = "ai_insights"
 
+    __table_args__ = (Index("ix_ai_insights_keyword", "keyword"),)
+
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    keyword: Mapped[str] = mapped_column(String(200), nullable=False)
     trend_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("trends.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -1,0 +1,29 @@
+"""AI router — keyword analysis endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.ai import AnalyzeRequest, AnalyzeResult
+from app.services.ai import analyze_keyword
+
+router = APIRouter()
+
+
+@router.post(
+    "/analyze",
+    summary="AI 趋势词分析（商业建议 + 情感极性 + 相关词）",
+    response_model=AnalyzeResult,
+)
+async def analyze(
+    body: AnalyzeRequest,
+    db: AsyncSession = Depends(get_db),
+) -> AnalyzeResult:
+    """Analyze a trend keyword using the configured LLM provider.
+
+    Returns business insight, sentiment polarity, and 5 related keywords.
+    Result is persisted to the ``ai_insights`` table.
+    """
+    return await analyze_keyword(keyword=body.keyword, db=db)

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -1,0 +1,22 @@
+"""Pydantic schemas for AI analysis endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class AnalyzeRequest(BaseModel):
+    keyword: str
+
+
+class AnalyzeResult(BaseModel):
+    id: int
+    keyword: str
+    business_insight: str
+    sentiment: Literal["positive", "negative", "neutral"]
+    related_keywords: list[str]
+    model: str | None
+    created_at: datetime

--- a/backend/app/services/ai.py
+++ b/backend/app/services/ai.py
@@ -1,0 +1,58 @@
+"""AI service — keyword analysis via LLM, persisted to ai_insights table."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.factory import LLMFactory
+from app.models.ai_insight import AIInsight
+from app.schemas.ai import AnalyzeResult
+
+logger = logging.getLogger(__name__)
+
+
+async def analyze_keyword(keyword: str, db: AsyncSession) -> AnalyzeResult:
+    """Call the configured LLM provider to analyze a trend keyword.
+
+    Persists the result to the ``ai_insights`` table and returns a structured
+    :class:`~app.schemas.ai.AnalyzeResult`.
+    """
+    provider = LLMFactory.create()
+    response = await provider.analyze(keyword=keyword)
+
+    # response.content is JSON-encoded structured data
+    try:
+        structured = json.loads(response.content)
+    except json.JSONDecodeError:
+        structured = {
+            "business_insight": response.content,
+            "sentiment": "neutral",
+            "related_keywords": [],
+        }
+
+    insight = AIInsight(
+        keyword=keyword,
+        insight_type=response.insight_type,
+        content=response.content,
+        model=response.model,
+    )
+    db.add(insight)
+    await db.commit()
+    await db.refresh(insight)
+
+    sentiment = structured.get("sentiment", "neutral")
+    if sentiment not in {"positive", "negative", "neutral"}:
+        sentiment = "neutral"
+
+    return AnalyzeResult(
+        id=insight.id,
+        keyword=keyword,
+        business_insight=structured.get("business_insight", ""),
+        sentiment=sentiment,
+        related_keywords=structured.get("related_keywords", [])[:5],
+        model=insight.model,
+        created_at=insight.created_at,
+    )

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -1,12 +1,54 @@
-"""Unit tests for BaseLLMProvider, LLMFactory, and MiniMaxProvider."""
+"""Tests for AI analysis — MiniMaxProvider, LLMFactory, and /ai/analyze endpoint."""
 
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
+from httpx import AsyncClient
 
 from app.ai.base import AnalyzeResponse, BaseLLMProvider, ChatMessage, ChatResponse
 from app.ai.factory import LLMFactory
 from app.ai.minimax_provider import MiniMaxProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MOCK_ANALYSIS = {
+    "business_insight": "该词展示出强劲的商业潜力，建议重点关注电商与内容营销方向。",
+    "sentiment": "positive",
+    "related_keywords": ["电商", "营销", "流量", "品牌", "推广"],
+}
+
+_MINIMAX_RESPONSE = {
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": json.dumps(_MOCK_ANALYSIS, ensure_ascii=False),
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 50, "completion_tokens": 100, "total_tokens": 150},
+    "model": "abab6.5s-chat",
+}
+
+
+def _mock_http_client(response_body: dict):
+    """Return a patched httpx.AsyncClient that returns response_body."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = response_body
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    return mock_client
 
 
 # ---------------------------------------------------------------------------
@@ -15,14 +57,11 @@ from app.ai.minimax_provider import MiniMaxProvider
 
 
 def test_base_provider_is_abstract():
-    """Cannot instantiate BaseLLMProvider directly."""
     with pytest.raises(TypeError):
         BaseLLMProvider()  # type: ignore[abstract]
 
 
 def test_concrete_provider_must_implement_both_methods():
-    """A subclass that implements only chat() remains abstract."""
-
     class PartialProvider(BaseLLMProvider):
         provider_name = "partial"
 
@@ -34,7 +73,7 @@ def test_concrete_provider_must_implement_both_methods():
 
 
 # ---------------------------------------------------------------------------
-# ChatMessage / ChatResponse / AnalyzeResponse dataclasses
+# Dataclass smoke tests
 # ---------------------------------------------------------------------------
 
 
@@ -55,7 +94,7 @@ def test_analyze_response_defaults():
 
 
 # ---------------------------------------------------------------------------
-# MiniMaxProvider stub
+# MiniMaxProvider — mocked HTTP
 # ---------------------------------------------------------------------------
 
 
@@ -66,36 +105,68 @@ def test_minimax_provider_name():
 @pytest.mark.asyncio
 async def test_minimax_chat_returns_chat_response():
     provider = MiniMaxProvider()
-    messages = [ChatMessage(role="user", content="Tell me about AI trends")]
-    resp = await provider.chat(messages)
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        resp = await provider.chat([ChatMessage(role="user", content="你好")])
     assert isinstance(resp, ChatResponse)
-    assert resp.content  # non-empty
-    assert resp.model
-
-
-@pytest.mark.asyncio
-async def test_minimax_chat_echoes_user_message():
-    provider = MiniMaxProvider()
-    messages = [ChatMessage(role="user", content="Hello stub")]
-    resp = await provider.chat(messages)
-    assert "Hello stub" in resp.content
-
-
-@pytest.mark.asyncio
-async def test_minimax_analyze_returns_analyze_response():
-    provider = MiniMaxProvider()
-    resp = await provider.analyze(keyword="AI大模型", insight_type="business")
-    assert isinstance(resp, AnalyzeResponse)
-    assert resp.insight_type == "business"
     assert resp.content
-    assert resp.model
+    assert resp.model == "abab6.5s-chat"
 
 
 @pytest.mark.asyncio
-async def test_minimax_analyze_contains_keyword():
+async def test_minimax_analyze_returns_structured_data():
     provider = MiniMaxProvider()
-    resp = await provider.analyze(keyword="量子计算")
-    assert "量子计算" in resp.content
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        result = await provider.analyze(keyword="双十一")
+    parsed = json.loads(result.content)
+    assert parsed["sentiment"] == "positive"
+    assert isinstance(parsed["related_keywords"], list)
+    assert len(parsed["related_keywords"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_minimax_analyze_returns_analyze_response_type():
+    provider = MiniMaxProvider()
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        result = await provider.analyze(keyword="AI大模型", insight_type="business")
+    assert isinstance(result, AnalyzeResponse)
+    assert result.insight_type == "business"
+    assert result.model == "abab6.5s-chat"
+
+
+@pytest.mark.asyncio
+async def test_minimax_analyze_normalises_invalid_sentiment():
+    provider = MiniMaxProvider()
+    bad_body = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {"business_insight": "ok", "sentiment": "mixed", "related_keywords": []}
+                    ),
+                }
+            }
+        ],
+        "usage": {},
+    }
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(bad_body)):
+        result = await provider.analyze(keyword="测试词")
+    parsed = json.loads(result.content)
+    assert parsed["sentiment"] == "neutral"
+
+
+@pytest.mark.asyncio
+async def test_minimax_analyze_handles_non_json_response():
+    provider = MiniMaxProvider()
+    non_json_body = {
+        "choices": [{"message": {"role": "assistant", "content": "普通文字，不是JSON。"}}],
+        "usage": {},
+    }
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(non_json_body)):
+        result = await provider.analyze(keyword="测试词")
+    parsed = json.loads(result.content)
+    assert parsed["sentiment"] == "neutral"
+    assert "business_insight" in parsed
 
 
 # ---------------------------------------------------------------------------
@@ -122,3 +193,60 @@ def test_llm_factory_default_uses_settings(monkeypatch):
     monkeypatch.setattr("app.config.settings.llm_provider", "minimax")
     provider = LLMFactory.create()
     assert isinstance(provider, MiniMaxProvider)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: POST /api/v1/ai/analyze
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_endpoint_returns_200(test_client: AsyncClient):
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        resp = await test_client.post("/api/v1/ai/analyze", json={"keyword": "双十一"})
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_analyze_endpoint_response_schema(test_client: AsyncClient):
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        data = (await test_client.post("/api/v1/ai/analyze", json={"keyword": "双十一"})).json()
+    required = {"id", "keyword", "business_insight", "sentiment", "related_keywords", "model", "created_at"}
+    assert required <= set(data.keys())
+    assert data["keyword"] == "双十一"
+    assert data["sentiment"] in {"positive", "negative", "neutral"}
+    assert isinstance(data["related_keywords"], list)
+
+
+@pytest.mark.asyncio
+async def test_analyze_endpoint_persists_to_db(test_client: AsyncClient):
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        resp1 = (await test_client.post("/api/v1/ai/analyze", json={"keyword": "春节"})).json()
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(_MINIMAX_RESPONSE)):
+        resp2 = (await test_client.post("/api/v1/ai/analyze", json={"keyword": "春节"})).json()
+    # Two separate calls → two rows → distinct IDs
+    assert resp1["id"] != resp2["id"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_endpoint_related_keywords_max_5(test_client: AsyncClient):
+    long_body = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {
+                            "business_insight": "商业建议",
+                            "sentiment": "positive",
+                            "related_keywords": ["a", "b", "c", "d", "e", "f", "g"],
+                        }
+                    ),
+                }
+            }
+        ],
+        "usage": {},
+    }
+    with patch("httpx.AsyncClient", return_value=_mock_http_client(long_body)):
+        data = (await test_client.post("/api/v1/ai/analyze", json={"keyword": "测试"})).json()
+    assert len(data["related_keywords"]) <= 5


### PR DESCRIPTION
## Summary
- Implements `POST /api/v1/ai/analyze` — accepts `keyword`, calls MiniMax ChatCompletion V2 API, returns business insight, sentiment polarity, and 5 related keywords
- Rewrites `MiniMaxProvider` from stub to real `httpx` API client with structured JSON prompt
- Persists results to `ai_insights` table (added `keyword` column to model)
- 19 unit + integration tests, all mocked — no real API key required in CI

## Test plan
- [x] `pytest tests/test_ai.py` — 19 tests pass
- [x] Full suite: 103 tests pass
- [x] `ruff check` + `black --check` clean

Closes #19