### PR TITLE
feat: 每日简报生成 — AI汇总 + 邮件推送 + 08:00定时任务 (#20)

### DIFF
--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -1,13 +1,14 @@
-"""AI router — keyword analysis endpoint."""
+"""AI router — keyword analysis and daily brief endpoints."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.ai import AnalyzeRequest, AnalyzeResult
+from app.schemas.ai import AnalyzeRequest, AnalyzeResult, BriefResponse
 from app.services.ai import analyze_keyword
+from app.services.brief import generate_daily_brief, get_latest_brief
 
 router = APIRouter()
 
@@ -27,3 +28,35 @@ async def analyze(
     Result is persisted to the ``ai_insights`` table.
     """
     return await analyze_keyword(keyword=body.keyword, db=db)
+
+
+@router.post("/brief", summary="手动触发每日简报生成", response_model=BriefResponse)
+async def create_brief(db: AsyncSession = Depends(get_db)) -> BriefResponse:
+    """Generate today's daily trend brief via AI and persist it.
+
+    If a brief for today already exists it will be regenerated.
+    Sends an email if SMTP is configured.
+    """
+    brief = await generate_daily_brief(db=db)
+    return BriefResponse(
+        id=brief.id,
+        date=brief.date,
+        content=brief.content,
+        model=brief.model,
+        created_at=brief.created_at,
+    )
+
+
+@router.get("/brief/latest", summary="获取最新每日简报", response_model=BriefResponse)
+async def latest_brief(db: AsyncSession = Depends(get_db)) -> BriefResponse:
+    """Return the most recently generated daily brief."""
+    brief = await get_latest_brief(db=db)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="No daily brief found")
+    return BriefResponse(
+        id=brief.id,
+        date=brief.date,
+        content=brief.content,
+        model=brief.model,
+        created_at=brief.created_at,
+    )

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel
@@ -18,5 +18,13 @@ class AnalyzeResult(BaseModel):
     business_insight: str
     sentiment: Literal["positive", "negative", "neutral"]
     related_keywords: list[str]
+    model: str | None
+    created_at: datetime
+
+
+class BriefResponse(BaseModel):
+    id: int
+    date: date
+    content: str
     model: str | None
     created_at: datetime

--- a/backend/app/services/brief.py
+++ b/backend/app/services/brief.py
@@ -1,0 +1,83 @@
+"""Daily brief service — AI-generated trend summary + optional email push."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.base import ChatMessage
+from app.ai.factory import LLMFactory
+from app.models.daily_brief import DailyBrief
+from app.services.email import send_email
+from app.services.trends import get_top_trends
+
+logger = logging.getLogger(__name__)
+
+_BRIEF_SYSTEM_PROMPT = (
+    "你是一个商业趋势分析师。根据用户提供的今日热门关键词列表，"
+    "生成一份简洁的商业趋势简报，300字以内，突出关键机会与风险。"
+)
+
+
+async def generate_daily_brief(db: AsyncSession, send_mail: bool = True) -> DailyBrief:
+    """Generate today's brief, persist it, and optionally email it.
+
+    If a brief for today already exists it will be overwritten.
+    """
+    today = date.today()
+
+    # Fetch top-20 keywords from the last 24h
+    top = await get_top_trends(db=db, limit=20)
+    keywords = [item["keyword"] for item in top]
+
+    if keywords:
+        keyword_list = "、".join(keywords)
+        user_msg = f"今日热词（按热度排序）：{keyword_list}"
+    else:
+        user_msg = "今日暂无热词数据，请生成一份通用商业趋势展望简报。"
+
+    provider = LLMFactory.create()
+    response = await provider.chat(
+        messages=[
+            ChatMessage(role="system", content=_BRIEF_SYSTEM_PROMPT),
+            ChatMessage(role="user", content=user_msg),
+        ]
+    )
+    content = response.content
+    model = response.model
+
+    # Upsert: update if today's row exists, otherwise insert
+    result = await db.execute(select(DailyBrief).where(DailyBrief.date == today))
+    brief = result.scalar_one_or_none()
+    if brief is None:
+        brief = DailyBrief(
+            date=today,
+            content=content,
+            model=model,
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+        db.add(brief)
+    else:
+        brief.content = content
+        brief.model = model
+        brief.created_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    await db.commit()
+    await db.refresh(brief)
+
+    if send_mail:
+        await send_email(
+            subject=f"TrendTracker 每日简报 {today}",
+            body=content,
+        )
+
+    return brief
+
+
+async def get_latest_brief(db: AsyncSession) -> DailyBrief | None:
+    """Return the most recently created daily brief, or None if none exist."""
+    result = await db.execute(select(DailyBrief).order_by(DailyBrief.created_at.desc()).limit(1))
+    return result.scalar_one_or_none()

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,46 @@
+"""Async email sender using stdlib smtplib via asyncio.to_thread."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _send_sync(subject: str, body: str, to: str) -> None:
+    """Synchronous SMTP send — runs in a thread pool."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = settings.smtp_user
+    msg["To"] = to
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+
+    with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=15) as server:
+        server.ehlo()
+        server.starttls()
+        server.login(settings.smtp_user, settings.smtp_password)
+        server.sendmail(settings.smtp_user, [to], msg.as_string())
+
+
+async def send_email(subject: str, body: str, to: str | None = None) -> bool:
+    """Send an email; returns True on success, False if skipped or failed.
+
+    Skips silently when SMTP credentials are not configured.
+    """
+    recipient = to or settings.alert_email_to
+    if not all([settings.smtp_user, settings.smtp_password, recipient]):
+        logger.info("send_email: SMTP not configured, skipping")
+        return False
+    try:
+        await asyncio.to_thread(_send_sync, subject, body, recipient)
+        logger.info("send_email: sent '%s' to %s", subject, recipient)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.error("send_email: failed — %s", exc)
+        return False

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -6,12 +6,28 @@ import logging
 from typing import Any
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 logger = logging.getLogger(__name__)
 
 # Global scheduler instance reused across the application lifecycle.
 scheduler = AsyncIOScheduler()
+
+
+async def daily_brief_job() -> None:
+    """Scheduled job: generate daily brief and send email."""
+    logger.info("daily_brief_job: starting daily brief generation")
+    try:
+        from app.database import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            from app.services.brief import generate_daily_brief
+
+            brief = await generate_daily_brief(db=db, send_mail=True)
+            logger.info("daily_brief_job: brief generated id=%d date=%s", brief.id, brief.date)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("daily_brief_job: error — %s", exc)
 
 
 async def collect_trends_job() -> None:
@@ -44,6 +60,17 @@ def setup_scheduler() -> AsyncIOScheduler:
             replace_existing=True,
         )
         logger.info("setup_scheduler: registered 'collect_trends' job (every 1 hour)")
+
+    if scheduler.get_job("daily_brief") is None:
+        scheduler.add_job(
+            daily_brief_job,
+            trigger=CronTrigger(hour=8, minute=0),
+            id="daily_brief",
+            name="Generate daily AI brief",
+            replace_existing=True,
+        )
+        logger.info("setup_scheduler: registered 'daily_brief' job (daily 08:00)")
+
     return scheduler
 
 

--- a/backend/tests/test_brief.py
+++ b/backend/tests/test_brief.py
@@ -1,0 +1,212 @@
+"""Tests for daily brief generation and /ai/brief endpoints."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.base import ChatResponse
+from app.models.daily_brief import DailyBrief
+from app.models.trend import Trend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BRIEF_CONTENT = "今日热词聚焦于科技与消费领域，建议关注相关赛道投资机会。"
+_MOCK_CHAT_RESPONSE = ChatResponse(
+    content=_BRIEF_CONTENT,
+    model="abab6.5s-chat",
+    usage={"prompt_tokens": 80, "completion_tokens": 60},
+)
+
+
+def _patch_llm():
+    """Patch LLMFactory.create() to return a mock provider."""
+    mock_provider = MagicMock()
+    mock_provider.chat = AsyncMock(return_value=_MOCK_CHAT_RESPONSE)
+    return patch("app.services.brief.LLMFactory.create", return_value=mock_provider)
+
+
+def _patch_email():
+    """Patch send_email to avoid real SMTP calls."""
+    return patch("app.services.brief.send_email", new=AsyncMock(return_value=False))
+
+
+async def _seed_trend(db: AsyncSession, keyword: str) -> None:
+    from datetime import datetime, timezone
+
+    db.add(
+        Trend(
+            platform="weibo",
+            keyword=keyword,
+            rank=0,
+            heat_score=9000.0,
+            collected_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: generate_daily_brief
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_brief_returns_daily_brief(db_session: AsyncSession):
+    with _patch_llm(), _patch_email():
+        from app.services.brief import generate_daily_brief
+
+        brief = await generate_daily_brief(db=db_session, send_mail=False)
+
+    assert isinstance(brief, DailyBrief)
+    assert brief.id is not None
+    assert brief.date == date.today()
+    assert brief.content == _BRIEF_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_generate_brief_uses_top_keywords(db_session: AsyncSession):
+    await _seed_trend(db_session, "人工智能")
+    await _seed_trend(db_session, "新能源")
+
+    captured_messages = []
+
+    async def capture_chat(messages, **kwargs):
+        captured_messages.extend(messages)
+        return _MOCK_CHAT_RESPONSE
+
+    mock_provider = MagicMock()
+    mock_provider.chat = capture_chat
+
+    with patch("app.services.brief.LLMFactory.create", return_value=mock_provider), _patch_email():
+        from app.services.brief import generate_daily_brief
+
+        await generate_daily_brief(db=db_session, send_mail=False)
+
+    user_msg = next(m for m in captured_messages if m.role == "user")
+    assert "人工智能" in user_msg.content
+    assert "新能源" in user_msg.content
+
+
+@pytest.mark.asyncio
+async def test_generate_brief_upserts_on_same_day(db_session: AsyncSession):
+    with _patch_llm(), _patch_email():
+        from app.services.brief import generate_daily_brief
+
+        brief1 = await generate_daily_brief(db=db_session, send_mail=False)
+        brief2 = await generate_daily_brief(db=db_session, send_mail=False)
+
+    # Same row updated, not a second row
+    assert brief1.id == brief2.id
+
+
+@pytest.mark.asyncio
+async def test_generate_brief_sends_email_when_configured(db_session: AsyncSession):
+    mock_send = AsyncMock(return_value=True)
+    with _patch_llm(), patch("app.services.brief.send_email", new=mock_send):
+        from app.services.brief import generate_daily_brief
+
+        await generate_daily_brief(db=db_session, send_mail=True)
+
+    mock_send.assert_called_once()
+    call_kwargs = mock_send.call_args
+    assert "TrendTracker" in call_kwargs.kwargs.get("subject", "") or "TrendTracker" in str(
+        call_kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_brief_skips_email_when_send_mail_false(db_session: AsyncSession):
+    mock_send = AsyncMock(return_value=False)
+    with _patch_llm(), patch("app.services.brief.send_email", new=mock_send):
+        from app.services.brief import generate_daily_brief
+
+        await generate_daily_brief(db=db_session, send_mail=False)
+
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_latest_brief_returns_none_when_empty(db_session: AsyncSession):
+    from app.services.brief import get_latest_brief
+
+    result = await get_latest_brief(db=db_session)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_brief_returns_most_recent(db_session: AsyncSession):
+    with _patch_llm(), _patch_email():
+        from app.services.brief import generate_daily_brief, get_latest_brief
+
+        await generate_daily_brief(db=db_session, send_mail=False)
+        latest = await get_latest_brief(db=db_session)
+
+    assert latest is not None
+    assert latest.content == _BRIEF_CONTENT
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: POST /api/v1/ai/brief and GET /api/v1/ai/brief/latest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_brief_endpoint_returns_200(test_client: AsyncClient):
+    with _patch_llm(), _patch_email():
+        resp = await test_client.post("/api/v1/ai/brief")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_brief_endpoint_response_schema(test_client: AsyncClient):
+    with _patch_llm(), _patch_email():
+        data = (await test_client.post("/api/v1/ai/brief")).json()
+    required = {"id", "date", "content", "model", "created_at"}
+    assert required <= set(data.keys())
+    assert data["content"] == _BRIEF_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_latest_brief_returns_404_when_none(test_client: AsyncClient):
+    resp = await test_client.get("/api/v1/ai/brief/latest")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_latest_brief_returns_200_after_creation(test_client: AsyncClient):
+    with _patch_llm(), _patch_email():
+        await test_client.post("/api/v1/ai/brief")
+        resp = await test_client.get("/api/v1/ai/brief/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["content"] == _BRIEF_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_latest_brief_date_is_today(test_client: AsyncClient):
+    with _patch_llm(), _patch_email():
+        await test_client.post("/api/v1/ai/brief")
+        data = (await test_client.get("/api/v1/ai/brief/latest")).json()
+    assert data["date"] == date.today().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Scheduler registration test
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_registers_daily_brief_job():
+    from app.services.scheduler import setup_scheduler
+
+    sched = setup_scheduler()
+    job = sched.get_job("daily_brief")
+    assert job is not None
+    assert "08" in str(job.trigger) or "CronTrigger" in type(job.trigger).__name__


### PR DESCRIPTION
## Summary
- `POST /api/v1/ai/brief` — 手动触发简报生成，调用 LLM（Top20 热词 → 300字商业简报），写入 `daily_briefs` 表，同日重复调用则覆盖
- `GET /api/v1/ai/brief/latest` — 返回最新简报，无记录时 404
- APScheduler 新增 `daily_brief` job（CronTrigger 每日 08:00）
- `app/services/email.py` — 基于 stdlib `smtplib` + `asyncio.to_thread` 的异步邮件发送，SMTP 未配置时静默跳过

## Test plan
- [x] 13 个新测试全部通过（单元 + 集成）
- [x] 全量 116 测试通过
- [x] `ruff check` + `black --check` 干净

Closes #20