### PR TITLE
feat(backend): GoogleTrendsCollector — RSS采集 Top20 + geo支持 (#22)

### DIFF
--- a/backend/app/collectors/__init__.py
+++ b/backend/app/collectors/__init__.py
@@ -1,9 +1,20 @@
 from app.collectors.base import BaseCollector
+from app.collectors.google import GoogleTrendsCollector
+from app.collectors.google_mock import GoogleMockCollector
 from app.collectors.registry import CollectorRegistry, registry
 from app.collectors.weibo import WeiboCollector
 from app.collectors.weibo_mock import WeiboMockCollector
 
-# Auto-register real collectors (WeiboCollector overwrites the mock)
+# Auto-register real collectors
 registry.register(WeiboCollector)
+registry.register(GoogleTrendsCollector)
 
-__all__ = ["BaseCollector", "CollectorRegistry", "WeiboCollector", "WeiboMockCollector", "registry"]
+__all__ = [
+    "BaseCollector",
+    "CollectorRegistry",
+    "GoogleMockCollector",
+    "GoogleTrendsCollector",
+    "WeiboCollector",
+    "WeiboMockCollector",
+    "registry",
+]

--- a/backend/app/collectors/google.py
+++ b/backend/app/collectors/google.py
@@ -1,0 +1,91 @@
+"""Google Trends real collector — daily trending searches via RSS feed."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import httpx
+
+from app.collectors.base import BaseCollector
+
+_RSS_URL = "https://trends.google.com/trends/trendingsearches/daily/rss"
+_NS = {"ht": "https://trends.google.com/trends/trendingsearches/daily"}
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/rss+xml, application/xml, text/xml, */*",
+}
+
+
+def _parse_traffic(traffic_str: str) -> float:
+    """Convert '1,000,000+' or '500K+' style strings to a float."""
+    s = traffic_str.strip().rstrip("+").replace(",", "").replace(" ", "")
+    if s.upper().endswith("K"):
+        try:
+            return float(s[:-1]) * 1_000
+        except ValueError:
+            return 0.0
+    if s.upper().endswith("M"):
+        try:
+            return float(s[:-1]) * 1_000_000
+        except ValueError:
+            return 0.0
+    try:
+        return float(s)
+    except ValueError:
+        return 0.0
+
+
+class GoogleTrendsCollector(BaseCollector):
+    """Collect Top-20 daily trending searches from Google Trends RSS feed.
+
+    Args:
+        geo: ISO 3166-1 alpha-2 country code, e.g. ``"US"``, ``"TW"``.
+    """
+
+    platform = "google"
+
+    def __init__(self, geo: str = "US") -> None:
+        self.geo = geo
+
+    async def collect(self) -> list[dict]:
+        """Fetch Top-20 trending searches for *geo* from Google Trends RSS.
+
+        Returns:
+            List of trend dicts with standard BaseCollector fields.
+        Raises:
+            httpx.HTTPError on network / HTTP failures.
+        """
+        now = self._now()
+        url = f"{_RSS_URL}?geo={self.geo}"
+
+        async with httpx.AsyncClient(headers=_HEADERS, timeout=15.0) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            xml_text = resp.text
+
+        root = ET.fromstring(xml_text)
+        items = root.findall(".//item")[:20]
+
+        results = []
+        for rank, item in enumerate(items):
+            title = item.findtext("title", "").strip()
+            if not title:
+                continue
+            traffic_str = item.findtext("ht:approx_traffic", "0", _NS)
+            heat = _parse_traffic(traffic_str)
+            link = item.findtext("link", "") or ""
+            results.append(
+                {
+                    "platform": self.platform,
+                    "keyword": title,
+                    "rank": rank,
+                    "heat_score": heat,
+                    "url": link,
+                    "collected_at": now,
+                }
+            )
+        return results

--- a/backend/app/collectors/google_mock.py
+++ b/backend/app/collectors/google_mock.py
@@ -1,0 +1,59 @@
+"""Google Trends mock collector — returns static fixture data for testing."""
+
+from __future__ import annotations
+
+from app.collectors.base import BaseCollector
+
+_MOCK_TRENDS = [
+    {
+        "keyword": "Artificial Intelligence",
+        "rank": 0,
+        "heat_score": 2_000_000.0,
+        "url": "https://trends.google.com/trends/explore?q=Artificial+Intelligence",
+    },
+    {
+        "keyword": "World Cup 2026",
+        "rank": 1,
+        "heat_score": 1_500_000.0,
+        "url": "https://trends.google.com/trends/explore?q=World+Cup+2026",
+    },
+    {
+        "keyword": "Stock Market",
+        "rank": 2,
+        "heat_score": 1_200_000.0,
+        "url": "https://trends.google.com/trends/explore?q=Stock+Market",
+    },
+    {
+        "keyword": "Electric Vehicle",
+        "rank": 3,
+        "heat_score": 900_000.0,
+        "url": "https://trends.google.com/trends/explore?q=Electric+Vehicle",
+    },
+    {
+        "keyword": "Cryptocurrency",
+        "rank": 4,
+        "heat_score": 750_000.0,
+        "url": "https://trends.google.com/trends/explore?q=Cryptocurrency",
+    },
+]
+
+
+class GoogleMockCollector(BaseCollector):
+    """Mock collector for Google Trends — returns fixed test data without network I/O."""
+
+    platform = "google"
+
+    async def collect(self) -> list[dict]:
+        """Return static mock trend data for Google Trends."""
+        now = self._now()
+        return [
+            {
+                "platform": self.platform,
+                "keyword": item["keyword"],
+                "rank": item["rank"],
+                "heat_score": item["heat_score"],
+                "url": item["url"],
+                "collected_at": now,
+            }
+            for item in _MOCK_TRENDS
+        ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 import app.models  # noqa: F401 — ensure all models are registered on Base.metadata
+from app.collectors.google_mock import GoogleMockCollector
 from app.collectors.registry import registry
 from app.collectors.weibo_mock import WeiboMockCollector
 from app.database import Base, get_db
@@ -17,13 +18,16 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
 @pytest.fixture(autouse=True)
 def use_mock_collector():
-    """Replace real WeiboCollector with WeiboMockCollector for all tests."""
+    """Replace real collectors with mocks for all tests (no network I/O)."""
     registry.register(WeiboMockCollector)
+    registry.register(GoogleMockCollector)
     yield
-    # Restore real collector after each test
+    # Restore real collectors after each test
+    from app.collectors.google import GoogleTrendsCollector
     from app.collectors.weibo import WeiboCollector
 
     registry.register(WeiboCollector)
+    registry.register(GoogleTrendsCollector)
 
 
 @pytest.fixture

--- a/backend/tests/test_google_collector.py
+++ b/backend/tests/test_google_collector.py
@@ -1,0 +1,220 @@
+"""Tests for GoogleTrendsCollector."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.collectors.google import GoogleTrendsCollector, _parse_traffic
+from app.collectors.google_mock import GoogleMockCollector
+
+# ---------------------------------------------------------------------------
+# Sample RSS XML fixture
+# ---------------------------------------------------------------------------
+
+_RSS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:ht="https://trends.google.com/trends/trendingsearches/daily">
+  <channel>
+    <title>Google Trends - Daily Trending Searches in United States</title>
+    <item>
+      <title>Artificial Intelligence</title>
+      <ht:approx_traffic>2,000,000+</ht:approx_traffic>
+      <link>https://trends.google.com/trends/explore?q=Artificial+Intelligence</link>
+    </item>
+    <item>
+      <title>World Cup 2026</title>
+      <ht:approx_traffic>1,500,000+</ht:approx_traffic>
+      <link>https://trends.google.com/trends/explore?q=World+Cup+2026</link>
+    </item>
+    <item>
+      <title>Stock Market</title>
+      <ht:approx_traffic>1,200,000+</ht:approx_traffic>
+      <link>https://trends.google.com/trends/explore?q=Stock+Market</link>
+    </item>
+  </channel>
+</rss>"""
+
+
+def _make_mock_response(xml_text: str = _RSS_XML):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = xml_text
+    return mock_resp
+
+
+def _patch_httpx(xml_text: str = _RSS_XML):
+    mock_resp = _make_mock_response(xml_text)
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    return patch("httpx.AsyncClient", return_value=mock_client)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_traffic
+# ---------------------------------------------------------------------------
+
+
+def test_parse_traffic_comma_format():
+    assert _parse_traffic("1,000,000+") == 1_000_000.0
+
+
+def test_parse_traffic_k_suffix():
+    assert _parse_traffic("500K+") == 500_000.0
+
+
+def test_parse_traffic_m_suffix():
+    assert _parse_traffic("2M+") == 2_000_000.0
+
+
+def test_parse_traffic_plain_number():
+    assert _parse_traffic("50000") == 50_000.0
+
+
+def test_parse_traffic_invalid_returns_zero():
+    assert _parse_traffic("N/A") == 0.0
+
+
+def test_parse_traffic_empty_returns_zero():
+    assert _parse_traffic("") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: GoogleTrendsCollector.collect (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_list():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+
+@pytest.mark.asyncio
+async def test_collect_platform_is_google():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    assert all(r["platform"] == "google" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_collect_item_schema():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    required = {"platform", "keyword", "rank", "heat_score", "url", "collected_at"}
+    for item in results:
+        assert required <= set(item.keys())
+
+
+@pytest.mark.asyncio
+async def test_collect_keyword_matches_title():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    keywords = [r["keyword"] for r in results]
+    assert "Artificial Intelligence" in keywords
+    assert "World Cup 2026" in keywords
+
+
+@pytest.mark.asyncio
+async def test_collect_heat_score_parsed_correctly():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    top = next(r for r in results if r["keyword"] == "Artificial Intelligence")
+    assert top["heat_score"] == 2_000_000.0
+
+
+@pytest.mark.asyncio
+async def test_collect_rank_is_zero_based():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    assert results[0]["rank"] == 0
+    assert results[1]["rank"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_collected_at_is_datetime():
+    with _patch_httpx():
+        results = await GoogleTrendsCollector().collect()
+    for r in results:
+        assert isinstance(r["collected_at"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_collect_truncates_at_20():
+    # Build RSS with 25 items
+    items_xml = "\n".join(
+        f"<item><title>Term{i}</title>"
+        f"<ht:approx_traffic>100,000+</ht:approx_traffic>"
+        f"<link>https://example.com/{i}</link></item>"
+        for i in range(25)
+    )
+    big_rss = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<rss version="2.0" xmlns:ht="https://trends.google.com/trends/trendingsearches/daily">'
+        f"<channel>{items_xml}</channel></rss>"
+    )
+    with _patch_httpx(big_rss):
+        results = await GoogleTrendsCollector().collect()
+    assert len(results) <= 20
+
+
+@pytest.mark.asyncio
+async def test_collect_custom_geo():
+    collector = GoogleTrendsCollector(geo="TW")
+    captured_url = []
+
+    mock_resp = _make_mock_response()
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    async def fake_get(url, **kwargs):
+        captured_url.append(url)
+        return mock_resp
+
+    mock_client.get = fake_get
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await collector.collect()
+
+    assert "geo=TW" in captured_url[0]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: GoogleMockCollector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_returns_list():
+    results = await GoogleMockCollector().collect()
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_platform_is_google():
+    results = await GoogleMockCollector().collect()
+    assert all(r["platform"] == "google" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_no_network():
+    # Must not raise even without network
+    results = await GoogleMockCollector().collect()
+    assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# Integration: registry picks up Google platform
+# ---------------------------------------------------------------------------
+
+
+def test_google_registered_in_registry():
+    from app.collectors.registry import registry
+
+    assert "google" in registry.list_platforms()


### PR DESCRIPTION
## Summary
- `GoogleTrendsCollector` 实现 `BaseCollector` 接口，通过 `httpx` 请求 Google Trends 每日 RSS feed（`/daily/rss?geo=US`）
- 解析 `<ht:approx_traffic>` 字段（支持 `1,000,000+` / `500K+` / `2M+` 格式）作为 `heat_score`
- 支持 `geo` 参数指定地区，默认 `US`，数据写入 `platform='google'`
- `GoogleMockCollector` 用于测试隔离，已加入 `conftest.py` autouse fixture
- 无需额外依赖（纯 `httpx` + 标准库 `xml.etree`）

## Test plan
- [x] 19 个新测试全部通过（含 `_parse_traffic` 单元测试 + 集成测试）
- [x] 全量 135 测试通过
- [x] `ruff check` + `black --check` 干净

Closes #22