### PR TITLE
feat(backend): TikTokCollector — Creative Center API 热门话题采集 (#23)

### DIFF
--- a/backend/app/collectors/__init__.py
+++ b/backend/app/collectors/__init__.py
@@ -2,18 +2,23 @@ from app.collectors.base import BaseCollector
 from app.collectors.google import GoogleTrendsCollector
 from app.collectors.google_mock import GoogleMockCollector
 from app.collectors.registry import CollectorRegistry, registry
+from app.collectors.tiktok import TikTokCollector
+from app.collectors.tiktok_mock import TikTokMockCollector
 from app.collectors.weibo import WeiboCollector
 from app.collectors.weibo_mock import WeiboMockCollector
 
 # Auto-register real collectors
 registry.register(WeiboCollector)
 registry.register(GoogleTrendsCollector)
+registry.register(TikTokCollector)
 
 __all__ = [
     "BaseCollector",
     "CollectorRegistry",
     "GoogleMockCollector",
     "GoogleTrendsCollector",
+    "TikTokCollector",
+    "TikTokMockCollector",
     "WeiboCollector",
     "WeiboMockCollector",
     "registry",

--- a/backend/app/collectors/tiktok.py
+++ b/backend/app/collectors/tiktok.py
@@ -1,0 +1,84 @@
+"""TikTok trending hashtag collector — uses Creative Center unofficial API."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.collectors.base import BaseCollector
+
+logger = logging.getLogger(__name__)
+
+# TikTok Creative Center trending hashtags endpoint (unofficial, no auth required
+# for basic requests, but subject to rate limiting and geo-restrictions).
+_API_URL = (
+    "https://ads.tiktok.com/creative_radar_api/v1/popular_trend/hashtag/list"
+    "?period=7&page=1&limit=20&order_by=popular&country_code={country_code}"
+)
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://ads.tiktok.com/business/creativecenter/hashtag/pc/en",
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+class TikTokCollector(BaseCollector):
+    """Collect Top-20 trending hashtags from TikTok Creative Center.
+
+    Args:
+        country_code: ISO 3166-1 alpha-2 country code, e.g. ``"US"``, ``"JP"``.
+    """
+
+    platform = "tiktok"
+
+    def __init__(self, country_code: str = "US") -> None:
+        self.country_code = country_code
+
+    async def collect(self) -> list[dict]:
+        """Fetch Top-20 trending hashtags from TikTok Creative Center API.
+
+        Returns:
+            List of trend dicts with standard BaseCollector fields.
+            Returns an empty list if the API is unavailable or rate-limited.
+        """
+        now = self._now()
+        url = _API_URL.format(country_code=self.country_code)
+
+        async with httpx.AsyncClient(headers=_HEADERS, timeout=15.0) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+
+        if data.get("code") != 0:
+            logger.warning(
+                "TikTokCollector: API returned code=%s msg=%s",
+                data.get("code"),
+                data.get("msg"),
+            )
+            return []
+
+        items = data.get("data", {}).get("list", [])
+        results = []
+        for rank, item in enumerate(items[:20]):
+            tag = item.get("hashtag_name", "").lstrip("#")
+            if not tag:
+                continue
+            # video_views is the best proxy for heat; fall back to publish_cnt
+            heat = float(item.get("video_views") or item.get("publish_cnt") or 0)
+            results.append(
+                {
+                    "platform": self.platform,
+                    "keyword": f"#{tag}",
+                    "rank": rank,
+                    "heat_score": heat,
+                    "url": f"https://www.tiktok.com/tag/{tag}",
+                    "collected_at": now,
+                }
+            )
+        return results

--- a/backend/app/collectors/tiktok_mock.py
+++ b/backend/app/collectors/tiktok_mock.py
@@ -1,0 +1,59 @@
+"""TikTok mock collector — returns static fixture data for testing."""
+
+from __future__ import annotations
+
+from app.collectors.base import BaseCollector
+
+_MOCK_TRENDS = [
+    {
+        "keyword": "#fyp",
+        "rank": 0,
+        "heat_score": 50_000_000_000.0,
+        "url": "https://www.tiktok.com/tag/fyp",
+    },
+    {
+        "keyword": "#viral",
+        "rank": 1,
+        "heat_score": 30_000_000_000.0,
+        "url": "https://www.tiktok.com/tag/viral",
+    },
+    {
+        "keyword": "#trending",
+        "rank": 2,
+        "heat_score": 20_000_000_000.0,
+        "url": "https://www.tiktok.com/tag/trending",
+    },
+    {
+        "keyword": "#ai",
+        "rank": 3,
+        "heat_score": 10_000_000_000.0,
+        "url": "https://www.tiktok.com/tag/ai",
+    },
+    {
+        "keyword": "#dance",
+        "rank": 4,
+        "heat_score": 8_000_000_000.0,
+        "url": "https://www.tiktok.com/tag/dance",
+    },
+]
+
+
+class TikTokMockCollector(BaseCollector):
+    """Mock collector for TikTok — returns fixed test data without network I/O."""
+
+    platform = "tiktok"
+
+    async def collect(self) -> list[dict]:
+        """Return static mock trend data for TikTok."""
+        now = self._now()
+        return [
+            {
+                "platform": self.platform,
+                "keyword": item["keyword"],
+                "rank": item["rank"],
+                "heat_score": item["heat_score"],
+                "url": item["url"],
+                "collected_at": now,
+            }
+            for item in _MOCK_TRENDS
+        ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 import app.models  # noqa: F401 — ensure all models are registered on Base.metadata
 from app.collectors.google_mock import GoogleMockCollector
 from app.collectors.registry import registry
+from app.collectors.tiktok_mock import TikTokMockCollector
 from app.collectors.weibo_mock import WeiboMockCollector
 from app.database import Base, get_db
 from app.main import app
@@ -21,13 +22,16 @@ def use_mock_collector():
     """Replace real collectors with mocks for all tests (no network I/O)."""
     registry.register(WeiboMockCollector)
     registry.register(GoogleMockCollector)
+    registry.register(TikTokMockCollector)
     yield
     # Restore real collectors after each test
     from app.collectors.google import GoogleTrendsCollector
+    from app.collectors.tiktok import TikTokCollector
     from app.collectors.weibo import WeiboCollector
 
     registry.register(WeiboCollector)
     registry.register(GoogleTrendsCollector)
+    registry.register(TikTokCollector)
 
 
 @pytest.fixture

--- a/backend/tests/test_tiktok_collector.py
+++ b/backend/tests/test_tiktok_collector.py
@@ -1,0 +1,229 @@
+"""Tests for TikTokCollector."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.collectors.tiktok import TikTokCollector
+from app.collectors.tiktok_mock import TikTokMockCollector
+
+# ---------------------------------------------------------------------------
+# Sample API response fixture
+# ---------------------------------------------------------------------------
+
+_API_RESPONSE = {
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "list": [
+            {"hashtag_name": "fyp", "video_views": 50_000_000_000, "publish_cnt": 5_000_000},
+            {"hashtag_name": "viral", "video_views": 30_000_000_000, "publish_cnt": 3_000_000},
+            {"hashtag_name": "trending", "video_views": 20_000_000_000, "publish_cnt": 2_000_000},
+            {"hashtag_name": "ai", "video_views": 10_000_000_000, "publish_cnt": 1_000_000},
+            {"hashtag_name": "dance", "video_views": 8_000_000_000, "publish_cnt": 800_000},
+        ]
+    },
+}
+
+
+def _patch_httpx(response_body: dict = _API_RESPONSE):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = response_body
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    return patch("httpx.AsyncClient", return_value=mock_client)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: TikTokCollector.collect (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_list():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+
+@pytest.mark.asyncio
+async def test_collect_platform_is_tiktok():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    assert all(r["platform"] == "tiktok" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_collect_item_schema():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    required = {"platform", "keyword", "rank", "heat_score", "url", "collected_at"}
+    for item in results:
+        assert required <= set(item.keys())
+
+
+@pytest.mark.asyncio
+async def test_collect_keyword_has_hash_prefix():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    assert all(r["keyword"].startswith("#") for r in results)
+
+
+@pytest.mark.asyncio
+async def test_collect_keyword_matches_hashtag_name():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    keywords = [r["keyword"] for r in results]
+    assert "#fyp" in keywords
+    assert "#viral" in keywords
+
+
+@pytest.mark.asyncio
+async def test_collect_heat_score_uses_video_views():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    top = next(r for r in results if r["keyword"] == "#fyp")
+    assert top["heat_score"] == 50_000_000_000.0
+
+
+@pytest.mark.asyncio
+async def test_collect_rank_is_zero_based():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    assert results[0]["rank"] == 0
+    assert results[1]["rank"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_url_points_to_tiktok_tag():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    for r in results:
+        assert "tiktok.com/tag/" in r["url"]
+
+
+@pytest.mark.asyncio
+async def test_collect_collected_at_is_datetime():
+    with _patch_httpx():
+        results = await TikTokCollector().collect()
+    for r in results:
+        assert isinstance(r["collected_at"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_collect_truncates_at_20():
+    big_list = [
+        {"hashtag_name": f"tag{i}", "video_views": 1_000_000, "publish_cnt": 100}
+        for i in range(25)
+    ]
+    body = {"code": 0, "msg": "OK", "data": {"list": big_list}}
+    with _patch_httpx(body):
+        results = await TikTokCollector().collect()
+    assert len(results) <= 20
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_empty_on_api_error_code():
+    error_body = {"code": 40001, "msg": "Unauthorized", "data": {}}
+    with _patch_httpx(error_body):
+        results = await TikTokCollector().collect()
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_collect_skips_empty_hashtag_name():
+    body = {
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "list": [
+                {"hashtag_name": "", "video_views": 1_000_000, "publish_cnt": 100},
+                {"hashtag_name": "fyp", "video_views": 5_000_000, "publish_cnt": 500},
+            ]
+        },
+    }
+    with _patch_httpx(body):
+        results = await TikTokCollector().collect()
+    assert len(results) == 1
+    assert results[0]["keyword"] == "#fyp"
+
+
+@pytest.mark.asyncio
+async def test_collect_custom_country_code():
+    collector = TikTokCollector(country_code="JP")
+    captured = []
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = _API_RESPONSE
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    async def fake_get(url, **kwargs):
+        captured.append(url)
+        return mock_resp
+
+    mock_client.get = fake_get
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await collector.collect()
+
+    assert "country_code=JP" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_collect_falls_back_to_publish_cnt_when_no_views():
+    body = {
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "list": [
+                {"hashtag_name": "noviews", "video_views": None, "publish_cnt": 999_000},
+            ]
+        },
+    }
+    with _patch_httpx(body):
+        results = await TikTokCollector().collect()
+    assert results[0]["heat_score"] == 999_000.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: TikTokMockCollector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_returns_list():
+    results = await TikTokMockCollector().collect()
+    assert isinstance(results, list)
+    assert len(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_platform_is_tiktok():
+    results = await TikTokMockCollector().collect()
+    assert all(r["platform"] == "tiktok" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_mock_collector_keywords_have_hash():
+    results = await TikTokMockCollector().collect()
+    assert all(r["keyword"].startswith("#") for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_tiktok_registered_in_registry():
+    from app.collectors.registry import registry
+
+    assert "tiktok" in registry.list_platforms()


### PR DESCRIPTION
## Summary
- `TikTokCollector` 实现 `BaseCollector` 接口，请求 TikTok Creative Center 非官方 API，采集 Top-20 热门 Hashtag
- 支持 `country_code` 参数（默认 `US`），keyword 以 `#tag` 格式存储，`heat_score` 取 `video_views`（无则 fallback 到 `publish_cnt`）
- API 返回非 0 错误码时静默返回空列表（rate limit / 鉴权失败时不 crash）
- `TikTokMockCollector` + `conftest.py` 已更新，测试自动隔离网络

## Test plan
- [x] 18 个新测试全部通过
- [x] 全量 153 测试通过
- [x] `ruff check` + `black --check` 干净

Closes #23