### PR TITLE
feat: 关键词监控 + 邮件告警 (#21)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.routers import ai as ai_router
+from app.routers import alerts as alerts_router
 from app.routers import collector as collector_router
 from app.routers import scheduler as scheduler_router
 from app.routers import trends as trends_router
@@ -49,3 +50,4 @@ app.include_router(scheduler_router.router, prefix="/api/v1/scheduler", tags=["S
 app.include_router(collector_router.router, prefix="/api/v1/collector", tags=["Collector"])
 app.include_router(trends_router.router, prefix="/api/v1/trends", tags=["Trends"])
 app.include_router(ai_router.router, prefix="/api/v1/ai", tags=["AI"])
+app.include_router(alerts_router.router, prefix="/api/v1/alerts", tags=["Alerts"])

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -1,0 +1,33 @@
+"""Alerts router — keyword monitoring rule endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.alerts import AlertRuleCreate, AlertRuleResponse, AlertRulesResponse
+from app.services.alerts import create_alert_rule, list_alert_rules
+
+router = APIRouter()
+
+
+@router.post("/keywords", summary="创建关键词监控规则", response_model=AlertRuleResponse)
+async def create_rule(
+    body: AlertRuleCreate,
+    db: AsyncSession = Depends(get_db),
+) -> AlertRuleResponse:
+    """Create a keyword alert rule. Fires an email when heat_score exceeds threshold."""
+    return await create_alert_rule(
+        keyword=body.keyword,
+        threshold=body.threshold,
+        notify_email=body.notify_email,
+        db=db,
+    )
+
+
+@router.get("/keywords", summary="列出所有监控规则", response_model=AlertRulesResponse)
+async def list_rules(db: AsyncSession = Depends(get_db)) -> AlertRulesResponse:
+    """Return all active keyword alert rules."""
+    items = await list_alert_rules(db=db)
+    return AlertRulesResponse(items=items)

--- a/backend/app/schemas/alerts.py
+++ b/backend/app/schemas/alerts.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for alert keyword endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, field_validator
+
+
+class AlertRuleCreate(BaseModel):
+    keyword: str
+    threshold: float
+    notify_email: str
+
+    @field_validator("threshold")
+    @classmethod
+    def threshold_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("threshold must be positive")
+        return v
+
+
+class AlertRuleResponse(BaseModel):
+    id: int
+    keyword: str
+    threshold: float
+    notify_email: str | None
+    is_active: bool
+    created_at: datetime
+
+
+class AlertRulesResponse(BaseModel):
+    items: list[AlertRuleResponse]

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -1,0 +1,164 @@
+"""Alert service — keyword monitoring rules and threshold-triggered email alerts."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.alert_log import AlertLog
+from app.models.keyword import Keyword
+from app.models.keyword_alert import KeywordAlert
+from app.models.trend import Trend
+from app.schemas.alerts import AlertRuleResponse
+from app.services.email import send_email
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CRUD helpers
+# ---------------------------------------------------------------------------
+
+
+async def create_alert_rule(
+    keyword: str,
+    threshold: float,
+    notify_email: str,
+    db: AsyncSession,
+) -> AlertRuleResponse:
+    """Create (or reactivate) a keyword monitoring rule.
+
+    If the keyword already exists in the ``keywords`` table it is reused.
+    A new ``KeywordAlert`` row is always created.
+    """
+    # Upsert Keyword row
+    result = await db.execute(select(Keyword).where(Keyword.keyword == keyword))
+    kw_row = result.scalar_one_or_none()
+    if kw_row is None:
+        kw_row = Keyword(keyword=keyword)
+        db.add(kw_row)
+        await db.flush()
+
+    alert = KeywordAlert(
+        keyword_id=kw_row.id,
+        threshold=threshold,
+        notify_email=notify_email,
+        is_active=True,
+    )
+    db.add(alert)
+    await db.commit()
+    await db.refresh(alert)
+
+    return AlertRuleResponse(
+        id=alert.id,
+        keyword=kw_row.keyword,
+        threshold=alert.threshold,
+        notify_email=alert.notify_email,
+        is_active=alert.is_active,
+        created_at=kw_row.created_at,
+    )
+
+
+async def list_alert_rules(db: AsyncSession) -> list[AlertRuleResponse]:
+    """Return all active alert rules with their keyword text."""
+    result = await db.execute(
+        select(KeywordAlert)
+        .where(KeywordAlert.is_active == True)  # noqa: E712
+        .options(selectinload(KeywordAlert.keyword_rel))
+        .order_by(KeywordAlert.id)
+    )
+    rules = result.scalars().all()
+    return [
+        AlertRuleResponse(
+            id=r.id,
+            keyword=r.keyword_rel.keyword,
+            threshold=r.threshold,
+            notify_email=r.notify_email,
+            is_active=r.is_active,
+            created_at=r.keyword_rel.created_at,
+        )
+        for r in rules
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Threshold check — called after each collection run
+# ---------------------------------------------------------------------------
+
+
+async def check_alerts(db: AsyncSession) -> int:
+    """Check all active alert rules against recent trend data.
+
+    For each active rule, look at trends collected in the last hour.
+    If any trend for that keyword exceeds the threshold, send an email and
+    write an ``AlertLog`` row.
+
+    Returns the number of alerts fired.
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    since = now - timedelta(hours=1)
+
+    # Load all active rules with their keywords
+    result = await db.execute(
+        select(KeywordAlert)
+        .where(KeywordAlert.is_active == True)  # noqa: E712
+        .options(selectinload(KeywordAlert.keyword_rel))
+    )
+    rules = result.scalars().all()
+    if not rules:
+        return 0
+
+    fired = 0
+    for rule in rules:
+        kw_text = rule.keyword_rel.keyword
+
+        # Find recent trends that match keyword and exceed threshold
+        trend_result = await db.execute(
+            select(Trend).where(
+                Trend.keyword == kw_text,
+                Trend.collected_at >= since,
+                Trend.heat_score >= rule.threshold,
+            )
+        )
+        matches = trend_result.scalars().all()
+        if not matches:
+            continue
+
+        best = max(matches, key=lambda t: t.heat_score or 0)
+        matched_info = f"{kw_text} heat={best.heat_score} platform={best.platform}"
+
+        # Write alert log
+        log = AlertLog(
+            keyword_id=rule.keyword_rel.id,
+            triggered_at=now,
+            matched_keywords=matched_info,
+            notified=False,
+        )
+        db.add(log)
+        await db.flush()
+
+        # Send email
+        subject = "[TrendTracker] " + kw_text + " heat=" + str(best.heat_score)
+        body = (
+            "keyword="
+            + kw_text
+            + " platform="
+            + best.platform
+            + " heat="
+            + str(best.heat_score)
+            + " threshold="
+            + str(rule.threshold)
+            + "\ncollected_at="
+            + str(best.collected_at)
+        )
+        notified = await send_email(subject=subject, body=body, to=rule.notify_email)
+        log.notified = notified
+        fired += 1
+        logger.info("check_alerts: fired alert for keyword=%r heat=%s", kw_text, best.heat_score)
+
+    await db.commit()
+    return fired

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -52,4 +52,10 @@ async def run_all_collectors(db: AsyncSession) -> dict:
             pass
 
     await db.commit()
+
+    # Check keyword alert thresholds after each collection run
+    from app.services.alerts import check_alerts
+
+    await check_alerts(db)
+
     return {"status": "ok", "records_count": total_records}

--- a/backend/tests/test_alerts.py
+++ b/backend/tests/test_alerts.py
@@ -1,0 +1,261 @@
+"""Tests for keyword alert rules and threshold-triggered email alerts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trend import Trend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_trend(
+    db: AsyncSession,
+    keyword: str,
+    heat: float,
+    platform: str = "weibo",
+    minutes_ago: int = 0,
+) -> None:
+    from datetime import timedelta
+
+    collected = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=minutes_ago)
+    db.add(Trend(platform=platform, keyword=keyword, rank=0, heat_score=heat, collected_at=collected))
+    await db.commit()
+
+
+def _patch_email(return_value: bool = True):
+    return patch("app.services.alerts.send_email", new=AsyncMock(return_value=return_value))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: create_alert_rule / list_alert_rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_alert_rule_returns_response(db_session: AsyncSession):
+    from app.services.alerts import create_alert_rule
+
+    result = await create_alert_rule("AI大模型", 5000.0, "test@example.com", db_session)
+    assert result.id is not None
+    assert result.keyword == "AI大模型"
+    assert result.threshold == 5000.0
+    assert result.notify_email == "test@example.com"
+    assert result.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_create_alert_rule_reuses_existing_keyword(db_session: AsyncSession):
+    from app.services.alerts import create_alert_rule
+
+    r1 = await create_alert_rule("热词", 1000.0, "a@example.com", db_session)
+    r2 = await create_alert_rule("热词", 2000.0, "b@example.com", db_session)
+    # Different alert rows, but same keyword (different IDs on alert)
+    assert r1.id != r2.id
+    assert r1.keyword == r2.keyword == "热词"
+
+
+@pytest.mark.asyncio
+async def test_list_alert_rules_empty(db_session: AsyncSession):
+    from app.services.alerts import list_alert_rules
+
+    result = await list_alert_rules(db_session)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_alert_rules_returns_created(db_session: AsyncSession):
+    from app.services.alerts import create_alert_rule, list_alert_rules
+
+    await create_alert_rule("词A", 1000.0, "x@example.com", db_session)
+    await create_alert_rule("词B", 2000.0, "y@example.com", db_session)
+    rules = await list_alert_rules(db_session)
+    assert len(rules) == 2
+    keywords = {r.keyword for r in rules}
+    assert keywords == {"词A", "词B"}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: check_alerts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_no_rules_returns_zero(db_session: AsyncSession):
+    from app.services.alerts import check_alerts
+
+    fired = await check_alerts(db_session)
+    assert fired == 0
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_fires_when_threshold_exceeded(db_session: AsyncSession):
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("双十一", 5000.0, "alert@example.com", db_session)
+    await _seed_trend(db_session, "双十一", heat=9000.0)
+
+    with _patch_email():
+        fired = await check_alerts(db_session)
+
+    assert fired == 1
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_no_fire_below_threshold(db_session: AsyncSession):
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("双十一", 5000.0, "alert@example.com", db_session)
+    await _seed_trend(db_session, "双十一", heat=3000.0)
+
+    with _patch_email():
+        fired = await check_alerts(db_session)
+
+    assert fired == 0
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_writes_alert_log(db_session: AsyncSession):
+    from sqlalchemy import select
+
+    from app.models.alert_log import AlertLog
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("新能源", 1000.0, "alert@example.com", db_session)
+    await _seed_trend(db_session, "新能源", heat=8000.0)
+
+    with _patch_email():
+        await check_alerts(db_session)
+
+    result = await db_session.execute(select(AlertLog))
+    logs = result.scalars().all()
+    assert len(logs) == 1
+    assert "新能源" in logs[0].matched_keywords
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_sends_email(db_session: AsyncSession):
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("元宇宙", 500.0, "alert@example.com", db_session)
+    await _seed_trend(db_session, "元宇宙", heat=9999.0)
+
+    mock_send = AsyncMock(return_value=True)
+    with patch("app.services.alerts.send_email", new=mock_send):
+        await check_alerts(db_session)
+
+    mock_send.assert_called_once()
+    call_kwargs = mock_send.call_args.kwargs
+    assert "元宇宙" in call_kwargs.get("subject", "")
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_marks_notified_true_on_email_success(db_session: AsyncSession):
+    from sqlalchemy import select
+
+    from app.models.alert_log import AlertLog
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("ChatGPT", 100.0, "alert@example.com", db_session)
+    await _seed_trend(db_session, "ChatGPT", heat=5000.0)
+
+    with patch("app.services.alerts.send_email", new=AsyncMock(return_value=True)):
+        await check_alerts(db_session)
+
+    result = await db_session.execute(select(AlertLog))
+    log = result.scalars().first()
+    assert log.notified is True
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_ignores_old_trends(db_session: AsyncSession):
+    from app.services.alerts import check_alerts, create_alert_rule
+
+    await create_alert_rule("过时词", 1000.0, "alert@example.com", db_session)
+    # 90 minutes old — outside the 1-hour window
+    await _seed_trend(db_session, "过时词", heat=99999.0, minutes_ago=90)
+
+    with _patch_email():
+        fired = await check_alerts(db_session)
+
+    assert fired == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: POST /api/v1/alerts/keywords and GET /api/v1/alerts/keywords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rule_endpoint_returns_200(test_client: AsyncClient):
+    resp = await test_client.post(
+        "/api/v1/alerts/keywords",
+        json={"keyword": "AI", "threshold": 5000.0, "notify_email": "x@example.com"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_rule_endpoint_response_schema(test_client: AsyncClient):
+    data = (
+        await test_client.post(
+            "/api/v1/alerts/keywords",
+            json={"keyword": "AI", "threshold": 5000.0, "notify_email": "x@example.com"},
+        )
+    ).json()
+    required = {"id", "keyword", "threshold", "notify_email", "is_active", "created_at"}
+    assert required <= set(data.keys())
+    assert data["keyword"] == "AI"
+    assert data["threshold"] == 5000.0
+    assert data["is_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_rule_rejects_zero_threshold(test_client: AsyncClient):
+    resp = await test_client.post(
+        "/api/v1/alerts/keywords",
+        json={"keyword": "AI", "threshold": 0.0, "notify_email": "x@example.com"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_rules_empty(test_client: AsyncClient):
+    data = (await test_client.get("/api/v1/alerts/keywords")).json()
+    assert data == {"items": []}
+
+
+@pytest.mark.asyncio
+async def test_list_rules_after_creation(test_client: AsyncClient):
+    await test_client.post(
+        "/api/v1/alerts/keywords",
+        json={"keyword": "词X", "threshold": 1000.0, "notify_email": "x@example.com"},
+    )
+    data = (await test_client.get("/api/v1/alerts/keywords")).json()
+    assert len(data["items"]) == 1
+    assert data["items"][0]["keyword"] == "词X"
+
+
+@pytest.mark.asyncio
+async def test_collector_triggers_alert_check(test_client: AsyncClient, db_session: AsyncSession):
+    """POST /collector/run should trigger check_alerts after persisting trends."""
+    from app.services.alerts import create_alert_rule
+
+    # The mock collector seeds weibo trends; set threshold low enough to fire
+    await create_alert_rule("ChatGPT最新版", 100.0, "alert@example.com", db_session)
+
+    mock_send = AsyncMock(return_value=True)
+    with patch("app.services.alerts.send_email", new=mock_send):
+        resp = await test_client.post("/api/v1/collector/run")
+
+    assert resp.status_code == 200
+    # Email should have been attempted for the matching keyword
+    mock_send.assert_called()


### PR DESCRIPTION
## Summary
- `POST /api/v1/alerts/keywords` — 创建监控规则（keyword + threshold + notify_email），threshold<=0 返回 422
- `GET /api/v1/alerts/keywords` — 列出所有激活规则
- `check_alerts(db)` — 每次采集完成后自动触发，扫描过去 1 小时趋势数据，超阈值则发邮件 + 写 `alert_logs`
- 复用 `app/services/email.py`（SMTP 未配置时静默跳过）

## Test plan
- [x] 17 个新测试全部通过（含集成测试验证采集→告警联动）
- [x] 全量 170 测试通过
- [x] `ruff check` + `black --check` 干净

Closes #21