### PR TITLE
fix(collector): dedup by platform+hour + 90-day auto cleanup (#38)

### DIFF
--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.collectors.registry import registry
@@ -36,9 +37,20 @@ async def _collect_one(platform_slug: str) -> tuple[str, list[dict]]:
 async def run_all_collectors(db: AsyncSession) -> dict:
     """Run all registered collectors concurrently, persist results, return summary.
 
+    Each platform uses replace-by-hour semantics: existing records for the same
+    platform within the current clock-hour are deleted before inserting the fresh
+    batch.  This prevents duplicate rows when collection is triggered more than
+    once within the same hour (e.g. manual + scheduled), while preserving all
+    cross-hour historical data for trend charts.
+
     Returns a dict with ``status`` and ``records_count``.
     """
     platforms = registry.list_platforms()
+
+    # Current hour bucket (naive UTC, matching DB storage)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    hour_start = now.replace(minute=0, second=0, microsecond=0)
+    hour_end = hour_start + timedelta(hours=1)
 
     # Collect from all platforms in parallel
     results = await asyncio.gather(*(_collect_one(slug) for slug in platforms))
@@ -47,6 +59,16 @@ async def run_all_collectors(db: AsyncSession) -> dict:
     for platform_slug, records in results:
         if not records:
             continue
+
+        # Replace-by-hour: remove stale records in the current hour bucket
+        await db.execute(
+            delete(Trend).where(
+                Trend.platform == platform_slug,
+                Trend.collected_at >= hour_start,
+                Trend.collected_at < hour_end,
+            )
+        )
+
         platform_id = await _ensure_platform(db, platform_slug)
         for rec in records:
             db.add(

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -15,6 +15,27 @@ logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
 
 
+async def cleanup_old_trends_job() -> None:
+    """Scheduled job: delete trend records older than 90 days."""
+    logger.info("cleanup_old_trends_job: starting cleanup")
+    try:
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import delete
+
+        from app.database import AsyncSessionLocal
+        from app.models.trend import Trend
+
+        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=90)
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(delete(Trend).where(Trend.collected_at < cutoff))
+            await db.commit()
+            deleted = result.rowcount
+        logger.info("cleanup_old_trends_job: deleted %d records older than 90 days", deleted)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("cleanup_old_trends_job: error — %s", exc)
+
+
 async def daily_brief_job() -> None:
     """Scheduled job: generate daily brief and send email."""
     logger.info("daily_brief_job: starting daily brief generation")
@@ -70,6 +91,16 @@ def setup_scheduler() -> AsyncIOScheduler:
             replace_existing=True,
         )
         logger.info("setup_scheduler: registered 'daily_brief' job (daily 08:00)")
+
+    if scheduler.get_job("cleanup_old_trends") is None:
+        scheduler.add_job(
+            cleanup_old_trends_job,
+            trigger=CronTrigger(hour=3, minute=0),
+            id="cleanup_old_trends",
+            name="Delete trend records older than 90 days",
+            replace_existing=True,
+        )
+        logger.info("setup_scheduler: registered 'cleanup_old_trends' job (daily 03:00)")
 
     return scheduler
 

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trend import Trend
 
 # ---------------------------------------------------------------------------
 # POST /api/v1/collector/run
@@ -117,3 +123,48 @@ async def test_trends_platforms_response_schema(test_client: AsyncClient):
 async def test_trends_platforms_contains_weibo(test_client: AsyncClient):
     resp = await test_client.get("/api/v1/trends/platforms")
     assert "weibo" in resp.json()["platforms"]
+
+
+# ---------------------------------------------------------------------------
+# Dedup: repeat collection within same hour should not grow record count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeat_collection_same_hour_does_not_duplicate(
+    test_client: AsyncClient, db_session: AsyncSession
+):
+    """Two collection runs within the same hour should yield the same row count."""
+    await test_client.post("/api/v1/collector/run")
+    count_result = await db_session.execute(select(func.count()).select_from(Trend))
+    count_after_first = count_result.scalar_one()
+
+    await test_client.post("/api/v1/collector/run")
+    count_result = await db_session.execute(select(func.count()).select_from(Trend))
+    count_after_second = count_result.scalar_one()
+
+    assert count_after_second == count_after_first
+
+
+@pytest.mark.asyncio
+async def test_cross_hour_data_is_preserved(
+    test_client: AsyncClient, db_session: AsyncSession
+):
+    """Records from a previous hour must survive a new collection run."""
+    # Manually insert a record from 2 hours ago
+    old_time = datetime.now(timezone.utc).replace(tzinfo=None, minute=0, second=0, microsecond=0)
+    from datetime import timedelta
+    old_time = old_time - timedelta(hours=2)
+    db_session.add(
+        Trend(platform="weibo", keyword="历史词", rank=0, heat_score=999.0, collected_at=old_time)
+    )
+    await db_session.commit()
+
+    # Run collection (current hour) — should not touch the old record
+    await test_client.post("/api/v1/collector/run")
+
+    result = await db_session.execute(
+        select(Trend).where(Trend.keyword == "历史词")
+    )
+    old_rows = result.scalars().all()
+    assert len(old_rows) == 1, "Cross-hour historical record should not be deleted"

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.services.scheduler import collect_trends_job, get_jobs_status, setup_scheduler
+from app.services.scheduler import (
+    cleanup_old_trends_job,
+    collect_trends_job,
+    get_jobs_status,
+    setup_scheduler,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +97,34 @@ async def test_scheduler_status_endpoint():
     assert "running" in data
     assert "jobs" in data
     assert isinstance(data["jobs"], list)
+
+
+def test_setup_scheduler_registers_cleanup_job():
+    sched = setup_scheduler()
+    job = sched.get_job("cleanup_old_trends")
+    assert job is not None
+    assert job.id == "cleanup_old_trends"
+
+
+def test_cleanup_job_trigger_is_cron():
+    from apscheduler.triggers.cron import CronTrigger
+
+    sched = setup_scheduler()
+    job = sched.get_job("cleanup_old_trends")
+    assert isinstance(job.trigger, CronTrigger)
+
+
+def test_get_jobs_status_contains_cleanup():
+    setup_scheduler()
+    status = get_jobs_status()
+    ids = [j["id"] for j in status]
+    assert "cleanup_old_trends" in ids
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_trends_job_runs_without_error():
+    """The cleanup job should not raise even when the DB has no old records."""
+    await cleanup_old_trends_job()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Replace-by-hour dedup**: before inserting fresh records, delete any existing records for that platform within the current clock-hour. Same-hour re-collection overwrites instead of duplicating. Cross-hour historical data is untouched.
- **90-day cleanup job**: new `cleanup_old_trends` CronTrigger(hour=3) scheduler job deletes records older than 90 days daily, fulfilling PRD retention requirement.

## Test plan

- [x] 180/180 tests pass
- [x] `ruff` + `black` clean
- [x] `test_repeat_collection_same_hour_does_not_duplicate` — verifies no row growth on second run
- [x] `test_cross_hour_data_is_preserved` — verifies old-hour records survive new collection
- [x] `test_setup_scheduler_registers_cleanup_job` / trigger / status visible

Closes #38