### PR TITLE
fix(collectors): update Google Trends URL + TikTok cookie auth (#40)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ LLM_PROVIDER=minimax
 MINIMAX_API_KEY=your_minimax_key_here
 MINIMAX_GROUP_ID=your_group_id_here
 
+# TikTok Creative Center (required for TikTok collection)
+# How to get: open ads.tiktok.com in browser while logged in → DevTools →
+# Network → any XHR request → copy the full "Cookie" request header value
+TIKTOK_COOKIE=
+
 # Scheduler (cron: every day at 06:00)
 COLLECT_CRON=0 6 * * *
 

--- a/backend/app/collectors/google.py
+++ b/backend/app/collectors/google.py
@@ -8,8 +8,8 @@ import httpx
 
 from app.collectors.base import BaseCollector
 
-_RSS_URL = "https://trends.google.com/trends/trendingsearches/daily/rss"
-_NS = {"ht": "https://trends.google.com/trends/trendingsearches/daily"}
+_RSS_URL = "https://trends.google.com/trending/rss"
+_NS = {"ht": "https://trends.google.com/trending/rss"}
 _HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "

--- a/backend/app/collectors/tiktok.py
+++ b/backend/app/collectors/tiktok.py
@@ -1,4 +1,14 @@
-"""TikTok trending hashtag collector — uses Creative Center unofficial API."""
+"""TikTok trending hashtag collector — uses Creative Center unofficial API.
+
+Authentication note
+-------------------
+TikTok's Creative Center API requires a valid login session.  Set the
+``TIKTOK_COOKIE`` environment variable to the full ``Cookie`` header value
+copied from an authenticated browser session on ``ads.tiktok.com``.
+
+If ``TIKTOK_COOKIE`` is not configured the collector returns an empty list and
+logs a warning — other platforms are unaffected.
+"""
 
 from __future__ import annotations
 
@@ -7,16 +17,15 @@ import logging
 import httpx
 
 from app.collectors.base import BaseCollector
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-# TikTok Creative Center trending hashtags endpoint (unofficial, no auth required
-# for basic requests, but subject to rate limiting and geo-restrictions).
 _API_URL = (
     "https://ads.tiktok.com/creative_radar_api/v1/popular_trend/hashtag/list"
     "?period=7&page=1&limit=20&order_by=popular&country_code={country_code}"
 )
-_HEADERS = {
+_BASE_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -25,11 +34,28 @@ _HEADERS = {
     "Referer": "https://ads.tiktok.com/business/creativecenter/hashtag/pc/en",
     "Accept": "application/json, text/plain, */*",
     "Accept-Language": "en-US,en;q=0.9",
+    "Origin": "https://ads.tiktok.com",
 }
+
+
+def _build_headers(cookie: str) -> dict[str, str]:
+    """Merge base headers with cookie and extract X-CSRFToken if present."""
+    headers = dict(_BASE_HEADERS)
+    headers["Cookie"] = cookie
+    # TikTok Creative Center requires X-CSRFToken matching the csrftoken cookie
+    for part in cookie.split(";"):
+        part = part.strip()
+        if part.startswith("csrftoken="):
+            headers["X-CSRFToken"] = part[len("csrftoken=") :]
+            break
+    return headers
 
 
 class TikTokCollector(BaseCollector):
     """Collect Top-20 trending hashtags from TikTok Creative Center.
+
+    Requires ``TIKTOK_COOKIE`` in the environment.  Returns ``[]`` and logs a
+    warning if the cookie is not configured or if the API rejects the request.
 
     Args:
         country_code: ISO 3166-1 alpha-2 country code, e.g. ``"US"``, ``"JP"``.
@@ -44,20 +70,31 @@ class TikTokCollector(BaseCollector):
         """Fetch Top-20 trending hashtags from TikTok Creative Center API.
 
         Returns:
-            List of trend dicts with standard BaseCollector fields.
-            Returns an empty list if the API is unavailable or rate-limited.
+            List of trend dicts with standard BaseCollector fields, or ``[]``
+            when authentication is not configured or the API rejects the request.
         """
+        cookie = settings.tiktok_cookie.strip()
+        if not cookie:
+            logger.warning(
+                "TikTokCollector: TIKTOK_COOKIE is not set — skipping collection. "
+                "Copy the Cookie header from an authenticated ads.tiktok.com browser "
+                "session and set it in your .env file."
+            )
+            return []
+
         now = self._now()
         url = _API_URL.format(country_code=self.country_code)
+        headers = _build_headers(cookie)
 
-        async with httpx.AsyncClient(headers=_HEADERS, timeout=15.0) as client:
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
             resp = await client.get(url)
             resp.raise_for_status()
             data = resp.json()
 
         if data.get("code") != 0:
             logger.warning(
-                "TikTokCollector: API returned code=%s msg=%s",
+                "TikTokCollector: API returned code=%s msg=%s — "
+                "cookie may be expired or invalid",
                 data.get("code"),
                 data.get("msg"),
             )
@@ -69,7 +106,6 @@ class TikTokCollector(BaseCollector):
             tag = item.get("hashtag_name", "").lstrip("#")
             if not tag:
                 continue
-            # video_views is the best proxy for heat; fall back to publish_cnt
             heat = float(item.get("video_views") or item.get("publish_cnt") or 0)
             results.append(
                 {

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,9 @@ class Settings(BaseSettings):
     # Scheduler
     collect_cron: str = "0 6 * * *"
 
+    # TikTok
+    tiktok_cookie: str = ""  # Paste browser Cookie header from ads.tiktok.com session
+
     # Email
     smtp_host: str = "smtp.gmail.com"
     smtp_port: int = 587

--- a/backend/tests/test_google_collector.py
+++ b/backend/tests/test_google_collector.py
@@ -15,23 +15,23 @@ from app.collectors.google_mock import GoogleMockCollector
 # ---------------------------------------------------------------------------
 
 _RSS_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:ht="https://trends.google.com/trends/trendingsearches/daily">
+<rss version="2.0" xmlns:ht="https://trends.google.com/trending/rss">
   <channel>
-    <title>Google Trends - Daily Trending Searches in United States</title>
+    <title>Daily Search Trends</title>
     <item>
       <title>Artificial Intelligence</title>
       <ht:approx_traffic>2,000,000+</ht:approx_traffic>
-      <link>https://trends.google.com/trends/explore?q=Artificial+Intelligence</link>
+      <link>https://trends.google.com/trending/rss?geo=US</link>
     </item>
     <item>
       <title>World Cup 2026</title>
       <ht:approx_traffic>1,500,000+</ht:approx_traffic>
-      <link>https://trends.google.com/trends/explore?q=World+Cup+2026</link>
+      <link>https://trends.google.com/trending/rss?geo=US</link>
     </item>
     <item>
       <title>Stock Market</title>
       <ht:approx_traffic>1,200,000+</ht:approx_traffic>
-      <link>https://trends.google.com/trends/explore?q=Stock+Market</link>
+      <link>https://trends.google.com/trending/rss?geo=US</link>
     </item>
   </channel>
 </rss>"""
@@ -155,7 +155,7 @@ async def test_collect_truncates_at_20():
     )
     big_rss = (
         '<?xml version="1.0" encoding="UTF-8"?>'
-        '<rss version="2.0" xmlns:ht="https://trends.google.com/trends/trendingsearches/daily">'
+        '<rss version="2.0" xmlns:ht="https://trends.google.com/trending/rss">'
         f"<channel>{items_xml}</channel></rss>"
     )
     with _patch_httpx(big_rss):

--- a/backend/tests/test_tiktok_collector.py
+++ b/backend/tests/test_tiktok_collector.py
@@ -29,7 +29,14 @@ _API_RESPONSE = {
 }
 
 
+_FAKE_COOKIE = "csrftoken=testtoken; sessionid=abc123"
+
+
 def _patch_httpx(response_body: dict = _API_RESPONSE):
+    """Patch httpx.AsyncClient AND settings.tiktok_cookie for collector tests."""
+    from contextlib import ExitStack
+    from unittest.mock import patch as _patch
+
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = response_body
@@ -37,7 +44,20 @@ def _patch_httpx(response_body: dict = _API_RESPONSE):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.get = AsyncMock(return_value=mock_resp)
-    return patch("httpx.AsyncClient", return_value=mock_client)
+
+    class _Combined:
+        def __enter__(self):
+            self._stack = ExitStack()
+            self._stack.enter_context(_patch("httpx.AsyncClient", return_value=mock_client))
+            self._stack.enter_context(
+                _patch("app.collectors.tiktok.settings.tiktok_cookie", _FAKE_COOKIE)
+            )
+            return mock_client
+
+        def __exit__(self, *args):
+            self._stack.__exit__(*args)
+
+    return _Combined()
 
 
 # ---------------------------------------------------------------------------
@@ -172,10 +192,52 @@ async def test_collect_custom_country_code():
         return mock_resp
 
     mock_client.get = fake_get
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch("app.collectors.tiktok.settings.tiktok_cookie", _FAKE_COOKIE),
+    ):
         await collector.collect()
 
     assert "country_code=JP" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_empty_when_cookie_not_configured():
+    """Without TIKTOK_COOKIE configured, collector returns [] without hitting network."""
+    with patch("app.collectors.tiktok.settings.tiktok_cookie", ""):
+        results = await TikTokCollector().collect()
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_collect_sends_csrf_token_header():
+    """csrftoken value from cookie is forwarded as X-CSRFToken header."""
+    captured_headers: dict = {}
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = _API_RESPONSE
+
+    inner_client = AsyncMock()
+    inner_client.get = AsyncMock(return_value=mock_resp)
+
+    class FakeClient:
+        def __init__(self, headers=None, **kwargs):
+            captured_headers.update(headers or {})
+
+        async def __aenter__(self):
+            return inner_client
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("httpx.AsyncClient", FakeClient),
+        patch("app.collectors.tiktok.settings.tiktok_cookie", _FAKE_COOKIE),
+    ):
+        await TikTokCollector().collect()
+
+    assert captured_headers.get("X-CSRFToken") == "testtoken"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Google Trends**: old RSS endpoint returned 404; updated URL to `https://trends.google.com/trending/rss` and XML namespace to match. Now returns 10 items successfully.
- **TikTok**: Creative Center API now requires login session (`code=40101`). Added `TIKTOK_COOKIE` env var support — reads cookie, sets `Cookie` + `X-CSRFToken` headers. Returns `[]` with clear warning log when unconfigured (other platforms unaffected).

## Test plan

- [x] 182/182 tests pass
- [x] `ruff` + `black` clean
- [x] Google collector verified live: returns 10 items
- [x] `test_collect_returns_empty_when_cookie_not_configured` — graceful degradation
- [x] `test_collect_sends_csrf_token_header` — X-CSRFToken forwarded correctly
- [x] `.env.example` documents how to obtain TikTok cookie

Closes #40