### PR TITLE
fix(scheduler): collect_trends_job now persists data via run_all_collectors (#42)

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -52,22 +52,17 @@ async def daily_brief_job() -> None:
 
 
 async def collect_trends_job() -> None:
-    """Scheduled job: trigger all registered collectors and persist results.
-
-    In the MVP phase this logs a placeholder message.  Future implementation
-    will iterate :data:`~app.collectors.registry` and save to the database.
-    """
+    """Scheduled job: run all collectors and persist results to the database."""
     logger.info("collect_trends_job: starting trend collection run")
-    from app.collectors import registry
+    try:
+        from app.database import AsyncSessionLocal
+        from app.services.collector import run_all_collectors
 
-    for platform in registry.list_platforms():
-        try:
-            collector_cls = registry.get(platform)
-            collector = collector_cls()
-            results = await collector.collect()
-            logger.info("collect_trends_job: collected %d records from %s", len(results), platform)
-        except Exception as exc:  # noqa: BLE001
-            logger.error("collect_trends_job: error collecting from %s: %s", platform, exc)
+        async with AsyncSessionLocal() as db:
+            result = await run_all_collectors(db)
+        logger.info("collect_trends_job: done — %d records saved", result.get("records_count", 0))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("collect_trends_job: error — %s", exc)
 
 
 def setup_scheduler() -> AsyncIOScheduler:

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -77,8 +77,28 @@ def test_get_jobs_status_record_schema():
 
 @pytest.mark.asyncio
 async def test_collect_trends_job_runs_without_error():
-    """The job should complete without raising even when the DB is unavailable."""
+    """Job should not raise even when the DB is unavailable (exception is caught)."""
     await collect_trends_job()
+
+
+@pytest.mark.asyncio
+async def test_collect_trends_job_calls_run_all_collectors():
+    """collect_trends_job must delegate to run_all_collectors (data is actually saved)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    mock_run = AsyncMock(return_value={"status": "ok", "records_count": 7})
+    mock_db = AsyncMock()
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("app.database.AsyncSessionLocal", return_value=mock_ctx),
+        patch("app.services.collector.run_all_collectors", mock_run),
+    ):
+        await collect_trends_job()
+
+    mock_run.assert_called_once_with(mock_db)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

`collect_trends_job` 是早期占位实现：只调用 `collector.collect()` 打日志，没有 DB session，数据全部丢失。APScheduler 每小时触发一次但什么都不存，只有手动点「立即采集」才真正入库。

## 修复

仿照 `daily_brief_job` 的模式，打开 `AsyncSessionLocal` 并调用 `run_all_collectors(db)`：

```python
async with AsyncSessionLocal() as db:
    result = await run_all_collectors(db)
```

## 测试

- [x] 183/183 tests pass
- [x] `ruff` + `black` clean
- [x] 新增 `test_collect_trends_job_calls_run_all_collectors`：断言 job 确实以 DB session 调用了 `run_all_collectors`

Closes #42