### PR TITLE
feat(frontend): implement AI insights, alerts, and dashboard stats pages (#44)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,58 @@
+# TrendTracker — 待办事项
+
+> 最后更新：2026-03-20
+
+---
+
+## 🔴 高优先级（Bug / 核心功能缺失）
+
+- [x] **定时采集不入库** — `collect_trends_job` 未调用 `run_all_collectors`，数据全丢（已修复 #43）
+
+---
+
+## 🟡 中优先级（前端空壳，后端已就绪）
+
+- [ ] **AI 洞察页** (`/ai`) — 后端 `/api/v1/ai/analyze` 和 `/brief` 已完整实现，前端仅 "Coming soon"
+  - 关键词输入 → AI 分析（商业建议 + 情感极性 + 相关词）
+  - 展示最新每日简报
+  - 手动触发生成简报按钮
+
+- [ ] **告警监控页** (`/alerts`) — 后端 CRUD + 邮件触发已完整实现，前端仅 "Coming soon"
+  - 告警规则列表（关键词 + 阈值 + 邮件）
+  - 新建规则表单
+  - 告警日志展示
+
+- [ ] **仪表盘统计卡片** — 4 张卡片（采集次数、热词总数、AI 分析数、告警规则数）全部显示 `—`，未接 API
+  - `GET /api/v1/trends` 的 `total` 字段可用于热词总数
+  - `GET /api/v1/ai/insights` 可用于 AI 分析数
+  - `GET /api/v1/alerts/rules` 可用于告警规则数
+
+- [ ] **仪表盘数据源状态卡片** — 硬编码 "待接入"，应实时反映各平台状态（有无近期数据）
+
+---
+
+## 🟢 低优先级（技术债）
+
+- [ ] **`COLLECT_CRON` 环境变量无效** — `config.py` 有 `collect_cron` 字段，但 `scheduler.py` 硬编码 `IntervalTrigger(hours=1)`，该配置完全未被读取
+  - 修复：`setup_scheduler` 中读取 `settings.collect_cron` 解析为 `CronTrigger`，或改用 `IntervalTrigger` 读取间隔分钟数
+
+- [ ] **趋势列表页重复平台标签** — `frontend/app/trends/page.tsx` 有本地 `PLATFORM_LABELS` 字典，与 `frontend/lib/platform-config.ts` 重复，新增平台要改两处
+  - 修复：改为 `import { getPlatformMeta } from "@/lib/platform-config"`
+
+---
+
+## 📋 PRD 规划中，未开始
+
+- [ ] **F2.5 趋势历史折线图** — 单词热度随时间变化曲线（需要按 keyword + platform 查询历史数据）
+- [ ] **F3.4 AI 自由对话** — 基于当前趋势数据与 AI 问答（需要 chat 接口 + 前端对话 UI）
+- [ ] **F1.7 百度指数采集** — 需账号 Cookie，稳定性风险高，暂缓
+
+---
+
+## ⚙️ 数据源状态
+
+| 平台 | 状态 | 备注 |
+|------|------|------|
+| 微博 | ✅ 正常 | 无需配置 |
+| Google Trends | ✅ 正常 | 已更新 RSS 地址（#41），每次返回约 10 条 |
+| TikTok | ⚙️ 需配置 | 设置 `TIKTOK_COOKIE` 后可用，参见 `.env.example` |

--- a/frontend/app/ai/page.tsx
+++ b/frontend/app/ai/page.tsx
@@ -1,8 +1,217 @@
-export default function AIPage() {
+"use client"
+
+import { useState } from "react"
+import { Brain, Sparkles, RefreshCw, Search } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { api, type AnalyzeResult, type BriefResponse } from "@/lib/api"
+
+const SENTIMENT_CONFIG = {
+  positive: { label: "正面", className: "bg-green-100 text-green-700 border-green-200" },
+  negative: { label: "负面", className: "bg-red-100 text-red-700 border-red-200" },
+  neutral:  { label: "中性", className: "bg-gray-100 text-gray-600 border-gray-200" },
+}
+
+function BriefCard({
+  brief,
+  loading,
+  onGenerate,
+  generating,
+}: {
+  brief: BriefResponse | null
+  loading: boolean
+  onGenerate: () => void
+  generating: boolean
+}) {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">AI 洞察</h1>
-      <p className="text-muted-foreground mt-1">Coming soon</p>
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-yellow-500" />
+          每日趋势简报
+        </CardTitle>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onGenerate}
+          disabled={generating}
+          className="gap-1.5"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${generating ? "animate-spin" : ""}`} />
+          {generating ? "生成中…" : "生成简报"}
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        ) : brief ? (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              {brief.date}
+              {brief.model && <span className="ml-2 opacity-60">· {brief.model}</span>}
+            </p>
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">{brief.content}</p>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            暂无简报，点击「生成简报」创建今日摘要
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function AnalyzeResultCard({ result }: { result: AnalyzeResult }) {
+  const sentiment = SENTIMENT_CONFIG[result.sentiment] ?? SENTIMENT_CONFIG.neutral
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">{result.keyword}</CardTitle>
+          <Badge variant="outline" className={sentiment.className}>
+            {sentiment.label}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {new Date(result.created_at).toLocaleString("zh-CN")}
+          {result.model && <span className="ml-2 opacity-60">· {result.model}</span>}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-1">商业洞察</p>
+          <p className="text-sm leading-relaxed">{result.business_insight}</p>
+        </div>
+        {result.related_keywords.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">相关关键词</p>
+            <div className="flex flex-wrap gap-1.5">
+              {result.related_keywords.map((kw) => (
+                <Badge key={kw} variant="secondary" className="text-xs">
+                  {kw}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function AIPage() {
+  const [keyword, setKeyword] = useState("")
+  const [analyzing, setAnalyzing] = useState(false)
+  const [analyzeError, setAnalyzeError] = useState("")
+  const [result, setResult] = useState<AnalyzeResult | null>(null)
+
+  const [brief, setBrief] = useState<BriefResponse | null>(null)
+  const [briefLoading, setBriefLoading] = useState(true)
+  const [generating, setGenerating] = useState(false)
+
+  // Load latest brief on mount
+  useState(() => {
+    api.ai
+      .latestBrief()
+      .then(setBrief)
+      .catch(() => setBrief(null))
+      .finally(() => setBriefLoading(false))
+  })
+
+  const handleAnalyze = async () => {
+    if (!keyword.trim()) return
+    setAnalyzing(true)
+    setAnalyzeError("")
+    try {
+      const res = await api.ai.analyze(keyword.trim())
+      setResult(res)
+    } catch (e) {
+      setAnalyzeError(e instanceof Error ? e.message : "分析失败，请稍后重试")
+    } finally {
+      setAnalyzing(false)
+    }
+  }
+
+  const handleGenerate = async () => {
+    setGenerating(true)
+    try {
+      const res = await api.ai.generateBrief()
+      setBrief(res)
+    } catch {
+      // silently ignore
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <Brain className="w-6 h-6" />
+          AI 洞察
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">关键词商业分析 · 每日趋势简报</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Analyze panel */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">关键词分析</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex gap-2">
+                <Input
+                  placeholder="输入热词，例如：人工智能"
+                  value={keyword}
+                  onChange={(e) => setKeyword(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleAnalyze()}
+                  disabled={analyzing}
+                />
+                <Button onClick={handleAnalyze} disabled={analyzing || !keyword.trim()} className="gap-1.5 shrink-0">
+                  <Search className={`w-4 h-4 ${analyzing ? "animate-pulse" : ""}`} />
+                  {analyzing ? "分析中…" : "分析"}
+                </Button>
+              </div>
+              {analyzeError && (
+                <p className="text-sm text-destructive">{analyzeError}</p>
+              )}
+            </CardContent>
+          </Card>
+
+          {analyzing && (
+            <Card>
+              <CardContent className="pt-6 space-y-3">
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </CardContent>
+            </Card>
+          )}
+
+          {result && !analyzing && <AnalyzeResultCard result={result} />}
+        </div>
+
+        {/* Brief panel */}
+        <BriefCard
+          brief={brief}
+          loading={briefLoading}
+          onGenerate={handleGenerate}
+          generating={generating}
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/app/alerts/page.tsx
+++ b/frontend/app/alerts/page.tsx
@@ -1,8 +1,176 @@
-export default function AlertsPage() {
+"use client"
+
+import { useEffect, useState } from "react"
+import { Bell, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { api, type AlertRule } from "@/lib/api"
+
+function formatHeat(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`
+  return String(v)
+}
+
+function RuleRow({ rule }: { rule: AlertRule }) {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">告警监控</h1>
-      <p className="text-muted-foreground mt-1">Coming soon</p>
+    <div className="flex items-center gap-4 py-3 border-b last:border-0 px-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-sm">{rule.keyword}</span>
+          <Badge variant={rule.is_active ? "default" : "secondary"} className="text-xs">
+            {rule.is_active ? "监控中" : "已停用"}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          阈值：{formatHeat(rule.threshold)}
+          {rule.notify_email && <span className="ml-3">通知：{rule.notify_email}</span>}
+        </p>
+      </div>
+      <span className="text-xs text-muted-foreground shrink-0">
+        {new Date(rule.created_at).toLocaleDateString("zh-CN")}
+      </span>
+    </div>
+  )
+}
+
+export default function AlertsPage() {
+  const [rules, setRules] = useState<AlertRule[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [keyword, setKeyword] = useState("")
+  const [threshold, setThreshold] = useState("")
+  const [email, setEmail] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState("")
+
+  const loadRules = async () => {
+    try {
+      const res = await api.alerts.listRules()
+      setRules(res.items)
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { loadRules() }, [])
+
+  const handleCreate = async () => {
+    setFormError("")
+    if (!keyword.trim()) { setFormError("请输入关键词"); return }
+    const t = parseFloat(threshold)
+    if (isNaN(t) || t <= 0) { setFormError("阈值须为正数"); return }
+    if (!email.trim()) { setFormError("请输入通知邮箱"); return }
+
+    setSubmitting(true)
+    try {
+      const rule = await api.alerts.createRule(keyword.trim(), t, email.trim())
+      setRules((prev) => [rule, ...prev])
+      setKeyword("")
+      setThreshold("")
+      setEmail("")
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "创建失败，请重试")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <Bell className="w-6 h-6" />
+          告警监控
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">关键词热度超阈值时自动发送邮件通知</p>
+      </div>
+
+      {/* Create form */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Plus className="w-4 h-4" />
+            新建监控规则
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">关键词</label>
+              <Input
+                placeholder="例如：人工智能"
+                value={keyword}
+                onChange={(e) => setKeyword(e.target.value)}
+                disabled={submitting}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">热度阈值</label>
+              <Input
+                type="number"
+                placeholder="例如：10000"
+                value={threshold}
+                onChange={(e) => setThreshold(e.target.value)}
+                disabled={submitting}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">通知邮箱</label>
+              <Input
+                type="email"
+                placeholder="your@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={submitting}
+              />
+            </div>
+          </div>
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          <Button onClick={handleCreate} disabled={submitting} size="sm" className="gap-1.5">
+            <Plus className="w-3.5 h-3.5" />
+            {submitting ? "创建中…" : "创建规则"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Rules list */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            监控规则
+            {!loading && (
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                共 {rules.length} 条
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="px-4 py-3 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-56" />
+                </div>
+              ))}
+            </div>
+          ) : rules.length === 0 ? (
+            <div className="py-12 text-center text-muted-foreground">
+              <Trash2 className="w-8 h-8 mx-auto mb-2 opacity-20" />
+              <p className="text-sm">暂无监控规则，上方创建第一条</p>
+            </div>
+          ) : (
+            rules.map((rule) => <RuleRow key={rule.id} rule={rule} />)
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,30 +5,48 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { BarChart3, Brain, Bell, Database } from "lucide-react"
-import { api, type HealthStatus, type PlatformTrendItem } from "@/lib/api"
+import { api, type HealthStatus, type PlatformTrendItem, type BriefResponse } from "@/lib/api"
 import { TopKeywordsChart } from "@/components/TopKeywordsChart"
 import { getPlatformMeta } from "@/lib/platform-config"
 
 export default function DashboardPage() {
   const [health, setHealth] = useState<HealthStatus | null>(null)
   const [healthError, setHealthError] = useState(false)
+
+  const [totalTrends, setTotalTrends] = useState<number | null>(null)
+  const [alertCount, setAlertCount] = useState<number | null>(null)
+  const [brief, setBrief] = useState<BriefResponse | null>(null)
+
   const [platformTrends, setPlatformTrends] = useState<Record<string, PlatformTrendItem[]>>({})
   const [trendsLoading, setTrendsLoading] = useState(true)
 
   useEffect(() => {
-    api
-      .health()
-      .then((data) => setHealth(data))
-      .catch(() => setHealthError(true))
+    api.health().then(setHealth).catch(() => setHealthError(true))
+
+    api.trends
+      .list(1, 1)
+      .then((d) => setTotalTrends(d.total))
+      .catch(() => setTotalTrends(null))
+
+    api.alerts
+      .listRules()
+      .then((d) => setAlertCount(d.items.length))
+      .catch(() => setAlertCount(null))
+
+    api.ai
+      .latestBrief()
+      .then(setBrief)
+      .catch(() => setBrief(null))
 
     api.trends
       .topByPlatform(10)
-      .then((data) => setPlatformTrends(data.platforms))
+      .then((d) => setPlatformTrends(d.platforms))
       .catch(() => setPlatformTrends({}))
       .finally(() => setTrendsLoading(false))
   }, [])
 
   const platformEntries = Object.entries(platformTrends)
+  const activePlatforms = platformEntries.map(([p]) => p)
 
   return (
     <div className="space-y-6">
@@ -58,38 +76,52 @@ export default function DashboardPage() {
         </CardContent>
       </Card>
 
-      {/* Status Cards */}
+      {/* Stats Cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">数据采集</CardTitle>
+            <CardTitle className="text-sm font-medium">热词总数</CardTitle>
             <Database className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground mt-1">等待首次采集</p>
+            {totalTrends === null ? (
+              <Skeleton className="h-8 w-20" />
+            ) : (
+              <div className="text-2xl font-bold">{totalTrends.toLocaleString()}</div>
+            )}
+            <p className="text-xs text-muted-foreground mt-1">数据库历史记录</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">热词总数</CardTitle>
+            <CardTitle className="text-sm font-medium">已采集平台</CardTitle>
             <BarChart3 className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground mt-1">暂无数据</p>
+            {trendsLoading ? (
+              <Skeleton className="h-8 w-12" />
+            ) : (
+              <div className="text-2xl font-bold">{activePlatforms.length}</div>
+            )}
+            <p className="text-xs text-muted-foreground mt-1">近24小时有数据</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">AI 分析</CardTitle>
+            <CardTitle className="text-sm font-medium">今日简报</CardTitle>
             <Brain className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground mt-1">暂无分析记录</p>
+            {brief ? (
+              <div className="text-2xl font-bold">{brief.date}</div>
+            ) : (
+              <div className="text-2xl font-bold text-muted-foreground">—</div>
+            )}
+            <p className="text-xs text-muted-foreground mt-1">
+              {brief ? "AI 简报已生成" : "尚未生成今日简报"}
+            </p>
           </CardContent>
         </Card>
 
@@ -99,8 +131,12 @@ export default function DashboardPage() {
             <Bell className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground mt-1">暂未配置</p>
+            {alertCount === null ? (
+              <Skeleton className="h-8 w-12" />
+            ) : (
+              <div className="text-2xl font-bold">{alertCount}</div>
+            )}
+            <p className="text-xs text-muted-foreground mt-1">活跃监控规则</p>
           </CardContent>
         </Card>
       </div>
@@ -159,13 +195,31 @@ export default function DashboardPage() {
           <CardTitle className="text-base">数据源状态</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {["微博热搜", "Google Trends", "TikTok", "百度指数"].map((platform) => (
-              <Badge key={platform} variant="secondary">
-                {platform} · 待接入
-              </Badge>
-            ))}
-          </div>
+          {trendsLoading ? (
+            <div className="flex gap-2">
+              {[1, 2, 3].map((i) => <Skeleton key={i} className="h-6 w-24 rounded-full" />)}
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {(["weibo", "google", "tiktok"] as const).map((slug) => {
+                const meta = getPlatformMeta(slug)
+                const active = activePlatforms.includes(slug)
+                return (
+                  <Badge
+                    key={slug}
+                    variant={active ? "default" : "secondary"}
+                    className={active ? "bg-green-500 hover:bg-green-500" : ""}
+                  >
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full mr-1.5"
+                      style={{ backgroundColor: active ? "white" : meta.color, opacity: active ? 0.8 : 0.5 }}
+                    />
+                    {meta.displayName} · {active ? "有数据" : "无近期数据"}
+                  </Badge>
+                )
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -67,6 +67,37 @@ export interface HeatmapResponse {
   max_heat: number
 }
 
+export interface AnalyzeResult {
+  id: number
+  keyword: string
+  business_insight: string
+  sentiment: "positive" | "negative" | "neutral"
+  related_keywords: string[]
+  model: string | null
+  created_at: string
+}
+
+export interface BriefResponse {
+  id: number
+  date: string
+  content: string
+  model: string | null
+  created_at: string
+}
+
+export interface AlertRule {
+  id: number
+  keyword: string
+  threshold: number
+  notify_email: string | null
+  is_active: boolean
+  created_at: string
+}
+
+export interface AlertRulesResponse {
+  items: AlertRule[]
+}
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
@@ -79,5 +110,23 @@ export const api = {
       request<TopTrendsResponse>(`/api/v1/trends/top?limit=${limit}`),
     topByPlatform: (limit = 10) =>
       request<TopByPlatformResponse>(`/api/v1/trends/top-by-platform?limit=${limit}`),
+  },
+  ai: {
+    analyze: (keyword: string) =>
+      request<AnalyzeResult>("/api/v1/ai/analyze", {
+        method: "POST",
+        body: JSON.stringify({ keyword }),
+      }),
+    latestBrief: () => request<BriefResponse>("/api/v1/ai/brief/latest"),
+    generateBrief: () =>
+      request<BriefResponse>("/api/v1/ai/brief", { method: "POST" }),
+  },
+  alerts: {
+    listRules: () => request<AlertRulesResponse>("/api/v1/alerts/keywords"),
+    createRule: (keyword: string, threshold: number, notify_email: string) =>
+      request<AlertRule>("/api/v1/alerts/keywords", {
+        method: "POST",
+        body: JSON.stringify({ keyword, threshold, notify_email }),
+      }),
   },
 }


### PR DESCRIPTION
## Summary

- Connect all 4 dashboard stat cards to real APIs (trend total, active platforms, latest brief date, alert rule count)
- Implement \`/ai\` page: keyword analysis with sentiment badge / business insight / related keywords + daily brief card with generate button
- Implement \`/alerts\` page: create rule form (keyword + threshold + email) with validation + active rules list
- Add \`AnalyzeResult\`, \`BriefResponse\`, \`AlertRule\` types and corresponding API methods to \`lib/api.ts\`
- Add \`docs/TODO.md\` for project task tracking

Closes #44

## Test plan

- [ ] Dashboard stat cards show real numbers (not \`—\`)
- [ ] Platform status badges turn green when recent data exists
- [ ] AI page: enter a keyword → click 分析 → result card renders
- [ ] AI page: click 生成简报 → brief card updates
- [ ] Alerts page: fill form → click 创建规则 → rule appears in list
- [ ] Alerts page: empty state shows placeholder message

🤖 Generated with [Claude Code](https://claude.com/claude-code)