### PR TITLE
chore(docker): cache pip install layer — copy pyproject.toml before source

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,11 +9,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy all source code first (needed for editable install)
-COPY . .
+# Copy only dependency manifest first — this layer is cached until pyproject.toml changes
+COPY pyproject.toml .
+# Create a minimal stub so setuptools can resolve the package metadata without full source
+RUN mkdir -p app && touch app/__init__.py
 
-# Install Python dependencies (editable, with dev extras)
-RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -e ".[dev]"
+# Install Python dependencies — cached as long as pyproject.toml doesn't change
+RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple ".[dev]"
+
+# Now copy the real source code — changes here do NOT invalidate the pip cache layer above
+COPY . .
 
 EXPOSE 8000
 


### PR DESCRIPTION
## 问题
`COPY . .` 在 `pip install` 之前，任何源码改动都会使 pip 缓存层失效，导致每次 build 重装所有依赖。

## 修复
将 Dockerfile 拆成两阶段复制：
1. 先只 `COPY pyproject.toml .` + 创建空包骨架 → `pip install`（此层缓存）
2. 再 `COPY . .` 复制真正源码

只要 `pyproject.toml` 不变，pip install 层就命中缓存，build 时间大幅缩短。