### PR TITLE
feat(trends): CTE-scoped platform max + convergence_score ranking (#53)

### DIFF
--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -72,50 +72,69 @@ def _to_naive_utc(dt: datetime) -> datetime:
 
 
 async def get_trends(db: AsyncSession, page: int = 1, page_size: int = 20) -> dict:
-    """Return paginated trends with convergence_score, ordered by collected_at desc."""
-    offset = (page - 1) * page_size
+    """Return paginated trends sorted by convergence_score (cross-platform normalised).
+
+    Uses a CTE to compute per-platform max heat_score within the last 24 hours so that
+    heat normalisation is scoped to the same window as the displayed data — preventing
+    stale all-time maximums from deflating scores.  Sorting and pagination are performed
+    in Python because the recency-decay formula uses datetime arithmetic that is not
+    portable across MySQL (production) and SQLite (tests).
+    """
     now = datetime.now(timezone.utc).replace(tzinfo=None)
+    since = now - timedelta(hours=24)
+    offset = (page - 1) * page_size
 
-    count_result = await db.execute(select(func.count()).select_from(Trend))
-    total = count_result.scalar_one()
-
-    # Per-platform max heat for normalization (avoids cross-platform magnitude bias)
-    max_heat_rows = await db.execute(
-        select(Trend.platform, func.max(Trend.heat_score)).group_by(Trend.platform)
+    # CTE: per-platform max heat_score scoped to the last 24 h window.
+    # Scoping here matters: an all-time max from days ago would shrink current scores
+    # and distort cross-platform comparison.
+    platform_max_cte = (
+        select(
+            Trend.platform.label("platform"),
+            func.max(Trend.heat_score).label("max_heat"),
+        )
+        .where(Trend.collected_at >= since)
+        .group_by(Trend.platform)
+        .cte("platform_max")
     )
-    platform_max_heat: dict[str, float] = {
-        row.platform: float(row[1] or 0.0) for row in max_heat_rows
-    }
 
-    result = await db.execute(
-        select(Trend)
-        .order_by(Trend.collected_at.desc(), Trend.rank)
-        .offset(offset)
-        .limit(page_size)
-    )
-    trends = result.scalars().all()
+    # Fetch all 24 h records with their platform's max_heat attached via the CTE.
+    rows = (
+        await db.execute(
+            select(Trend, platform_max_cte.c.max_heat)
+            .join(platform_max_cte, Trend.platform == platform_max_cte.c.platform)
+            .where(Trend.collected_at >= since)
+        )
+    ).all()
 
-    items = []
-    for t in trends:
-        collected = _to_naive_utc(t.collected_at)
-        age_hours = max(0.0, (now - collected).total_seconds() / 3600)
+    # Score every record in Python (portable datetime arithmetic for recency decay).
+    scored: list[tuple[Trend, float]] = []
+    for t, max_heat in rows:
+        age_hours = max(0.0, (now - _to_naive_utc(t.collected_at)).total_seconds() / 3600)
         score = compute_convergence_score(
             heat_score=t.heat_score,
             rank=t.rank,
             age_hours=age_hours,
-            platform_max_heat=platform_max_heat.get(t.platform, 0.0),
+            platform_max_heat=float(max_heat or 0.0),
         )
-        items.append(
-            {
-                "platform": t.platform,
-                "keyword": t.keyword,
-                "rank": t.rank,
-                "heat_score": t.heat_score,
-                "url": t.url,
-                "collected_at": t.collected_at,
-                "convergence_score": score,
-            }
-        )
+        scored.append((t, score))
+
+    # Sort by convergence_score descending, then paginate in Python.
+    scored.sort(key=lambda x: x[1], reverse=True)
+    total = len(scored)
+    page_slice = scored[offset : offset + page_size]
+
+    items = [
+        {
+            "platform": t.platform,
+            "keyword": t.keyword,
+            "rank": t.rank,
+            "heat_score": t.heat_score,
+            "url": t.url,
+            "collected_at": t.collected_at,
+            "convergence_score": score,
+        }
+        for t, score in page_slice
+    ]
     return {"total": total, "page": page, "page_size": page_size, "items": items}
 
 

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -106,6 +106,47 @@ async def test_trends_list_page_out_of_range(test_client: AsyncClient):
     assert data["items"] == []
 
 
+@pytest.mark.asyncio
+async def test_trends_list_sorted_by_convergence_score(test_client: AsyncClient):
+    """Items must be returned in descending convergence_score order."""
+    await test_client.post("/api/v1/collector/run")
+    items = (await test_client.get("/api/v1/trends?page_size=100")).json()["items"]
+    assert len(items) > 1
+    scores = [item["convergence_score"] for item in items]
+    assert scores == sorted(scores, reverse=True), "Items not sorted by convergence_score desc"
+
+
+@pytest.mark.asyncio
+async def test_trends_list_total_reflects_24h_window(
+    test_client: AsyncClient, db_session: AsyncSession
+):
+    """total must count only records within the last 24 hours."""
+    from datetime import timedelta
+
+    from sqlalchemy import insert
+
+    from app.models.trend import Trend
+
+    # Insert one old record (outside 24h window)
+    old_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=48)
+    await db_session.execute(
+        insert(Trend).values(
+            platform="weibo",
+            keyword="old_keyword",
+            rank=0,
+            heat_score=1000.0,
+            url="",
+            collected_at=old_time,
+        )
+    )
+    await db_session.commit()
+
+    await test_client.post("/api/v1/collector/run")
+    data = (await test_client.get("/api/v1/trends")).json()
+    # The old record must not be counted
+    assert all(item["keyword"] != "old_keyword" for item in data["items"])
+
+
 # ---------------------------------------------------------------------------
 # GET /api/v1/trends/platforms
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题
趋势列表按 `collected_at DESC, rank` 排序，两个缺陷：
1. 跨平台浏览量量级不同（微博千万级 vs Google 万级），直接按 heat_score 排序不公平
2. `platform_max_heat` 取的是全量历史最大值，时间窗口不一致导致归一化失真

## 方案
**CTE 负责计算** — `platform_max` CTE 将 `MAX(heat_score)` 的统计范围限定在同一 24h 窗口内，JOIN 后每条记录携带正确的平台天花板值。

**Python 负责排序** — 时间衰减公式用 Python datetime 计算（可跨 MySQL/SQLite），按 `convergence_score DESC` 排序后再分页。

```
旧：SQL ORDER BY collected_at DESC, rank → LIMIT → Python 算分（顺序已错）
新：CTE max_heat(24h) → JOIN → Python 算分 → sort → slice
```

## 新增测试
- `test_trends_list_sorted_by_convergence_score`：验证返回列表分数严格降序
- `test_trends_list_total_reflects_24h_window`：验证 24h 以外的旧记录不计入 total

Closes #53