### PR TITLE
feat(scheduler): 采集频率分级 per-platform cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,15 @@ MINIMAX_GROUP_ID=your_group_id_here
 # Network → any XHR request → copy the full "Cookie" request header value
 TIKTOK_COOKIE=
 
-# Scheduler (cron: every day at 06:00)
+# Scheduler — global default (cron: every day at 06:00)
 COLLECT_CRON=0 6 * * *
+# Per-platform overrides (empty = use COLLECT_CRON)
+WEIBO_CRON=0 */2 * * *
+GOOGLE_CRON=
+TIKTOK_CRON=0 */6 * * *
+
+# Signal-driven AI analysis (max signals to auto-analyze per detection, 0 = disabled)
+SIGNAL_AUTO_ANALYZE_LIMIT=3
 
 # Email (for alerts)
 SMTP_HOST=smtp.gmail.com

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,8 +19,14 @@ class Settings(BaseSettings):
     minimax_api_key: str = ""
     minimax_group_id: str = ""
 
-    # Scheduler
+    # Scheduler — global default and per-platform overrides
     collect_cron: str = "0 6 * * *"
+    weibo_cron: str = "0 */2 * * *"  # every 2 hours (hot search has short half-life)
+    google_cron: str = ""  # empty = use collect_cron
+    tiktok_cron: str = "0 */6 * * *"  # every 6 hours
+
+    # Signal-driven AI analysis
+    signal_auto_analyze_limit: int = 3  # max signals to auto-analyze per detection run
 
     # TikTok
     tiktok_cookie: str = ""  # Paste browser Cookie header from ads.tiktok.com session

--- a/backend/app/routers/collector.py
+++ b/backend/app/routers/collector.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -12,8 +12,12 @@ from app.services.collector import run_all_collectors
 router = APIRouter()
 
 
-@router.post("/run", summary="手动触发全平台数据采集", response_model=CollectorRunResponse)
-async def collector_run(db: AsyncSession = Depends(get_db)) -> CollectorRunResponse:
-    """Manually trigger all registered collectors, persist results, and return summary."""
-    result = await run_all_collectors(db)
+@router.post("/run", summary="手动触发数据采集", response_model=CollectorRunResponse)
+async def collector_run(
+    platforms: str | None = Query(None, description="平台列表（逗号分隔），为空则采集全部平台"),
+    db: AsyncSession = Depends(get_db),
+) -> CollectorRunResponse:
+    """Manually trigger collectors. Optionally specify platforms (comma-separated)."""
+    platform_list = [p.strip() for p in platforms.split(",") if p.strip()] if platforms else None
+    result = await run_all_collectors(db, platforms=platform_list)
     return CollectorRunResponse(**result)

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -38,8 +38,16 @@ async def _collect_one(platform_slug: str) -> tuple[str, list[dict], str | None]
         return platform_slug, [], str(exc)
 
 
-async def run_all_collectors(db: AsyncSession) -> dict:
-    """Run all registered collectors concurrently, persist results, return summary.
+async def run_all_collectors(
+    db: AsyncSession,
+    platforms: list[str] | None = None,
+) -> dict:
+    """Run collectors concurrently, persist results, return summary.
+
+    Args:
+        db: async database session.
+        platforms: optional list of platform slugs to collect.
+                   If None, all registered platforms are collected.
 
     Each platform uses replace-by-hour semantics: existing records for the same
     platform within the current clock-hour are deleted before inserting the fresh
@@ -49,7 +57,8 @@ async def run_all_collectors(db: AsyncSession) -> dict:
 
     Returns a dict with ``status`` and ``records_count``.
     """
-    platforms = registry.list_platforms()
+    if platforms is None:
+        platforms = registry.list_platforms()
 
     # Current hour bucket (naive UTC, matching DB storage)
     now = datetime.now(timezone.utc).replace(tzinfo=None)

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Any
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -50,25 +51,73 @@ async def daily_brief_job() -> None:
         logger.error("daily_brief_job: error — %s", exc)
 
 
-async def collect_trends_job() -> None:
-    """Scheduled job: run all collectors and persist results to the database."""
-    logger.info("collect_trends_job: starting trend collection run")
+async def collect_trends_job(platforms: list[str] | None = None) -> None:
+    """Scheduled job: run collectors and persist results.
+
+    Args:
+        platforms: optional list of platform slugs. None = all platforms.
+    """
+    label = ",".join(platforms) if platforms else "all"
+    logger.info("collect_trends_job[%s]: starting", label)
     try:
         from app.database import AsyncSessionLocal
         from app.services.collector import run_all_collectors
 
         async with AsyncSessionLocal() as db:
-            result = await run_all_collectors(db)
-        logger.info("collect_trends_job: done — %d records saved", result.get("records_count", 0))
+            result = await run_all_collectors(db, platforms=platforms)
+        logger.info(
+            "collect_trends_job[%s]: done — %d records saved",
+            label,
+            result.get("records_count", 0),
+        )
     except Exception as exc:  # noqa: BLE001
-        logger.error("collect_trends_job: error — %s", exc)
+        logger.error("collect_trends_job[%s]: error — %s", label, exc)
+
+
+def _get_platform_crons() -> dict[str, str]:
+    """Return per-platform cron expressions from settings.
+
+    Platforms with an empty cron string inherit the global ``collect_cron``.
+    """
+    from app.config import settings
+
+    default = settings.collect_cron
+    mapping = {
+        "weibo": settings.weibo_cron,
+        "google": settings.google_cron,
+        "tiktok": settings.tiktok_cron,
+    }
+    # Fill empty values with default
+    return {platform: (cron or default) for platform, cron in mapping.items()}
 
 
 def setup_scheduler() -> AsyncIOScheduler:
-    """Register all recurring jobs and return the scheduler (not yet started)."""
-    if scheduler.get_job("collect_trends") is None:
-        from app.config import settings
+    """Register all recurring jobs and return the scheduler (not yet started).
 
+    Each platform gets its own collection job with an independent cron schedule.
+    A legacy ``collect_trends`` job is also registered (all platforms, global cron)
+    for backward compatibility — it fires if no per-platform overrides differ.
+    """
+    from app.config import settings
+
+    platform_crons = _get_platform_crons()
+
+    # --- Per-platform collection jobs ---
+    for platform, cron_expr in platform_crons.items():
+        job_id = f"collect_{platform}"
+        if scheduler.get_job(job_id) is None:
+            trigger = CronTrigger.from_crontab(cron_expr)
+            scheduler.add_job(
+                partial(collect_trends_job, platforms=[platform]),
+                trigger=trigger,
+                id=job_id,
+                name=f"Collect trends: {platform}",
+                replace_existing=True,
+            )
+            logger.info("setup_scheduler: registered '%s' job (cron=%s)", job_id, cron_expr)
+
+    # --- Legacy all-platforms job (for manual / backward compat) ---
+    if scheduler.get_job("collect_trends") is None:
         collect_trigger = CronTrigger.from_crontab(settings.collect_cron)
         scheduler.add_job(
             collect_trends_job,
@@ -78,9 +127,11 @@ def setup_scheduler() -> AsyncIOScheduler:
             replace_existing=True,
         )
         logger.info(
-            "setup_scheduler: registered 'collect_trends' job (cron=%s)", settings.collect_cron
+            "setup_scheduler: registered 'collect_trends' job (cron=%s)",
+            settings.collect_cron,
         )
 
+    # --- Daily brief ---
     if scheduler.get_job("daily_brief") is None:
         scheduler.add_job(
             daily_brief_job,
@@ -91,6 +142,7 @@ def setup_scheduler() -> AsyncIOScheduler:
         )
         logger.info("setup_scheduler: registered 'daily_brief' job (daily 08:00)")
 
+    # --- Cleanup ---
     if scheduler.get_job("cleanup_old_trends") is None:
         scheduler.add_job(
             cleanup_old_trends_job,

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -117,7 +117,7 @@ async def test_collect_trends_job_calls_run_all_collectors():
     ):
         await collect_trends_job()
 
-    mock_run.assert_called_once_with(mock_db)
+    mock_run.assert_called_once_with(mock_db, platforms=None)
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +164,63 @@ def test_get_jobs_status_contains_cleanup():
 async def test_cleanup_old_trends_job_runs_without_error():
     """The cleanup job should not raise even when the DB has no old records."""
     await cleanup_old_trends_job()
+
+
+# ---------------------------------------------------------------------------
+# Per-platform scheduler jobs
+# ---------------------------------------------------------------------------
+
+
+def test_setup_scheduler_registers_per_platform_jobs():
+    sched = setup_scheduler()
+    for platform in ("weibo", "google", "tiktok"):
+        job = sched.get_job(f"collect_{platform}")
+        assert job is not None, f"collect_{platform} job not registered"
+
+
+def test_per_platform_jobs_have_cron_trigger():
+    from apscheduler.triggers.cron import CronTrigger
+
+    sched = setup_scheduler()
+    for platform in ("weibo", "google", "tiktok"):
+        job = sched.get_job(f"collect_{platform}")
+        assert isinstance(job.trigger, CronTrigger)
+
+
+def test_per_platform_weibo_uses_custom_cron():
+    """Weibo should use its own cron (every 2h), not the global default."""
+    sched = setup_scheduler()
+    job = sched.get_job("collect_weibo")
+    # Default weibo_cron = "0 */2 * * *"
+    assert "*/2" in str(job.trigger)
+
+
+def test_get_jobs_status_contains_per_platform_jobs():
+    setup_scheduler()
+    status = get_jobs_status()
+    ids = [j["id"] for j in status]
+    for platform in ("weibo", "google", "tiktok"):
+        assert f"collect_{platform}" in ids
+
+
+@pytest.mark.asyncio
+async def test_collect_trends_job_with_platforms_param():
+    """collect_trends_job should pass platforms arg to run_all_collectors."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    mock_run = AsyncMock(return_value={"status": "ok", "records_count": 5})
+    mock_db = AsyncMock()
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("app.database.AsyncSessionLocal", return_value=mock_ctx),
+        patch("app.services.collector.run_all_collectors", mock_run),
+    ):
+        await collect_trends_job(platforms=["weibo"])
+
+    mock_run.assert_called_once_with(mock_db, platforms=["weibo"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- 支持为不同平台配置独立采集频率，不再共用单一 COLLECT_CRON
- 默认频率：微博 2h、Google 24h（继承全局）、TikTok 6h
- `run_all_collectors` 新增 `platforms` 参数，支持按需采集
- `POST /collector/run?platforms=weibo,google` 支持指定平台
- 保留 `collect_trends` 全量任务向后兼容

## Test plan

- [x] 每个平台注册独立 scheduler job
- [x] per-platform cron trigger 类型正确
- [x] 微博使用自定义 cron (*/2)
- [x] jobs status 包含 per-platform jobs
- [x] collect_trends_job 传递 platforms 参数
- [x] 全量 42 测试通过，ruff + black 无报错

Closes #64