### PR TITLE
feat(signals): AI 信号驱动分析 + 信号简报

### DIFF
--- a/backend/app/models/signal_log.py
+++ b/backend/app/models/signal_log.py
@@ -22,6 +22,9 @@ class SignalLog(Base):
     value: Mapped[Optional[float]] = mapped_column(
         Float, nullable=True, comment="信号量化值（如跃升位数、倍数等）"
     )
+    ai_summary: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True, comment="AI 自动分析摘要"
+    )
     detected_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
 
     def __repr__(self) -> str:

--- a/backend/app/routers/signals.py
+++ b/backend/app/routers/signals.py
@@ -12,6 +12,19 @@ from app.services.signals import detect_signals, get_recent_signals
 router = APIRouter()
 
 
+def _to_item(r) -> SignalItem:
+    return SignalItem(
+        id=r.id,
+        signal_type=r.signal_type,
+        platform=r.platform,
+        keyword=r.keyword,
+        description=r.description,
+        value=r.value,
+        ai_summary=r.ai_summary,
+        detected_at=r.detected_at,
+    )
+
+
 @router.get("/recent", summary="获取最近趋势信号", response_model=SignalListResponse)
 async def recent_signals(
     hours: int = Query(24, ge=1, le=168, description="回溯时间窗口（小时）"),
@@ -20,18 +33,7 @@ async def recent_signals(
 ) -> SignalListResponse:
     """Return recent trend signals (rank jumps, new entries, heat surges)."""
     rows = await get_recent_signals(db, hours=hours, limit=limit)
-    items = [
-        SignalItem(
-            id=r.id,
-            signal_type=r.signal_type,
-            platform=r.platform,
-            keyword=r.keyword,
-            description=r.description,
-            value=r.value,
-            detected_at=r.detected_at,
-        )
-        for r in rows
-    ]
+    items = [_to_item(r) for r in rows]
     return SignalListResponse(items=items, total=len(items))
 
 
@@ -41,16 +43,5 @@ async def trigger_detect(
 ) -> DetectResponse:
     """Manually trigger signal detection on current data."""
     signals = await detect_signals(db)
-    items = [
-        SignalItem(
-            id=s.id,
-            signal_type=s.signal_type,
-            platform=s.platform,
-            keyword=s.keyword,
-            description=s.description,
-            value=s.value,
-            detected_at=s.detected_at,
-        )
-        for s in signals
-    ]
+    items = [_to_item(s) for s in signals]
     return DetectResponse(signals_detected=len(items), items=items)

--- a/backend/app/schemas/signals.py
+++ b/backend/app/schemas/signals.py
@@ -14,6 +14,7 @@ class SignalItem(BaseModel):
     keyword: str
     description: str
     value: float | None
+    ai_summary: str | None = None
     detected_at: datetime
 
 

--- a/backend/app/services/brief.py
+++ b/backend/app/services/brief.py
@@ -12,28 +12,42 @@ from app.ai.base import ChatMessage
 from app.ai.factory import LLMFactory
 from app.models.daily_brief import DailyBrief
 from app.services.email import send_email
+from app.services.signals import get_recent_signals
 from app.services.trends import get_top_trends
 
 logger = logging.getLogger(__name__)
 
 _BRIEF_SYSTEM_PROMPT = (
-    "你是一个商业趋势分析师。根据用户提供的今日热门关键词列表，"
+    "你是一个商业趋势分析师。根据用户提供的趋势信号和热门关键词，"
     "生成一份简洁的商业趋势简报，300字以内，突出关键机会与风险。"
+    "优先分析趋势信号中标注的突增、新面孔和排名跃升词。"
 )
 
 
 async def generate_daily_brief(db: AsyncSession, send_mail: bool = True) -> DailyBrief:
     """Generate today's brief, persist it, and optionally email it.
 
+    Signal-driven: prioritizes recent signals, falls back to top keywords.
     If a brief for today already exists it will be overwritten.
     """
     today = date.today()
 
-    # Fetch top-20 keywords from the last 24h
+    # 1. Try signal-driven: use recent 24h signals as primary input
+    signals = await get_recent_signals(db, hours=24, limit=10)
+    signal_lines = []
+    for sig in signals:
+        line = f"[{sig.signal_type}] {sig.platform}: {sig.keyword} — {sig.description}"
+        signal_lines.append(line)
+
+    # 2. Fallback: top-20 keywords from the last 24h
     top = await get_top_trends(db=db, limit=20)
     keywords = [item["keyword"] for item in top]
 
-    if keywords:
+    if signal_lines:
+        signals_text = "\n".join(signal_lines)
+        keyword_text = "、".join(keywords[:10]) if keywords else "无"
+        user_msg = f"今日趋势信号：\n{signals_text}\n\n热门关键词：{keyword_text}"
+    elif keywords:
         keyword_list = "、".join(keywords)
         user_msg = f"今日热词（按热度排序）：{keyword_list}"
     else:

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -107,8 +107,14 @@ async def run_all_collectors(
     await check_alerts(db)
 
     # Detect trend signals (rank jumps, new entries, heat surges)
-    from app.services.signals import detect_signals
+    from app.services.signals import auto_analyze_signals, detect_signals
 
-    await detect_signals(db)
+    signals = await detect_signals(db)
+
+    # Auto-analyze top signals with AI (if configured)
+    from app.config import settings
+
+    if signals and settings.signal_auto_analyze_limit > 0:
+        await auto_analyze_signals(db, signals, limit=settings.signal_auto_analyze_limit)
 
     return {"status": "ok", "records_count": total_records, "platforms": platform_results}

--- a/backend/app/services/signals.py
+++ b/backend/app/services/signals.py
@@ -237,3 +237,38 @@ async def get_recent_signals(db: AsyncSession, hours: int = 24, limit: int = 50)
         .limit(limit)
     )
     return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Auto-analyze: AI-driven signal analysis
+# ---------------------------------------------------------------------------
+
+
+async def auto_analyze_signals(db: AsyncSession, signals: list[SignalLog], limit: int = 3) -> int:
+    """Automatically run AI analysis on the top-N signals by value.
+
+    Updates the ``ai_summary`` field on each analyzed SignalLog.
+    Returns the number of signals analyzed.
+    """
+    if not signals or limit <= 0:
+        return 0
+
+    # Sort by value descending (biggest jump / surge first), take top N
+    ranked = sorted(signals, key=lambda s: s.value or 0, reverse=True)[:limit]
+
+    analyzed = 0
+    for sig in ranked:
+        try:
+            from app.services.ai import analyze_keyword
+
+            result = await analyze_keyword(keyword=sig.keyword, db=db)
+            sig.ai_summary = result.business_insight[:500] if result.business_insight else None
+            analyzed += 1
+            logger.info("auto_analyze_signals: analyzed %r (%s)", sig.keyword, sig.signal_type)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("auto_analyze_signals: failed for %r — %s", sig.keyword, exc)
+
+    if analyzed:
+        await db.commit()
+
+    return analyzed

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -265,3 +265,87 @@ async def test_signals_detect_endpoint(test_client: AsyncClient):
     data = resp.json()
     assert "signals_detected" in data
     assert "items" in data
+
+
+@pytest.mark.asyncio
+async def test_signals_recent_includes_ai_summary_field(test_client: AsyncClient):
+    """API response should include ai_summary field (even if null)."""
+    resp = await test_client.get("/api/v1/signals/recent")
+    assert resp.status_code == 200
+    # Empty list is fine — just checking schema is valid
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: auto_analyze_signals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_analyze_empty_signals(db_session: AsyncSession):
+    """auto_analyze_signals with empty list should return 0."""
+    from app.services.signals import auto_analyze_signals
+
+    result = await auto_analyze_signals(db_session, [], limit=3)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_analyze_zero_limit(db_session: AsyncSession):
+    """auto_analyze_signals with limit=0 should return 0."""
+    from app.services.signals import auto_analyze_signals, detect_signals
+
+    await _seed_trend(db_session, "限制测试", rank=3, heat=8000, minutes_ago=0)
+    signals = await detect_signals(db_session)
+
+    result = await auto_analyze_signals(db_session, signals, limit=0)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_analyze_updates_ai_summary(db_session: AsyncSession):
+    """auto_analyze_signals should set ai_summary on analyzed signals."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.models.signal_log import SignalLog as SL
+    from app.services.signals import auto_analyze_signals, detect_signals
+
+    await _seed_trend(db_session, "AI分析测试", rank=1, heat=9000, minutes_ago=0)
+    signals = await detect_signals(db_session)
+    assert len(signals) >= 1
+
+    mock_result = AsyncMock()
+    mock_result.business_insight = "这是一个有商业价值的趋势"
+
+    with patch("app.services.ai.analyze_keyword", new=AsyncMock(return_value=mock_result)):
+        analyzed = await auto_analyze_signals(db_session, signals, limit=1)
+
+    assert analyzed == 1
+    # Check that ai_summary was persisted
+    result = await db_session.execute(select(SL).where(SL.ai_summary.isnot(None)))
+    logs_with_summary = result.scalars().all()
+    assert len(logs_with_summary) >= 1
+    assert "商业价值" in logs_with_summary[0].ai_summary
+
+
+@pytest.mark.asyncio
+async def test_auto_analyze_respects_limit(db_session: AsyncSession):
+    """auto_analyze_signals should only analyze up to limit signals."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.signals import auto_analyze_signals, detect_signals
+
+    # Seed multiple new entries
+    for i in range(5):
+        await _seed_trend(db_session, f"词{i}", rank=i + 1, heat=1000 * (i + 1), minutes_ago=0)
+    signals = await detect_signals(db_session)
+    assert len(signals) >= 3
+
+    mock_result = AsyncMock()
+    mock_result.business_insight = "分析结果"
+    mock_analyze = AsyncMock(return_value=mock_result)
+
+    with patch("app.services.ai.analyze_keyword", new=mock_analyze):
+        analyzed = await auto_analyze_signals(db_session, signals, limit=2)
+
+    assert analyzed == 2
+    assert mock_analyze.call_count == 2

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -205,19 +205,26 @@ export default function DashboardPage() {
                 return (
                   <div
                     key={sig.id}
-                    className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
+                    className="rounded-md border px-3 py-2 text-sm space-y-1"
                   >
-                    <Badge variant="outline" className={typeColor}>
-                      {typeLabel}
-                    </Badge>
-                    <span
-                      className="inline-block w-2 h-2 rounded-full shrink-0"
-                      style={{ backgroundColor: meta.color }}
-                    />
-                    <span className="font-medium truncate">{sig.keyword}</span>
-                    <span className="text-muted-foreground text-xs ml-auto shrink-0">
-                      {sig.description}
-                    </span>
+                    <div className="flex items-center gap-3">
+                      <Badge variant="outline" className={typeColor}>
+                        {typeLabel}
+                      </Badge>
+                      <span
+                        className="inline-block w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: meta.color }}
+                      />
+                      <span className="font-medium truncate">{sig.keyword}</span>
+                      <span className="text-muted-foreground text-xs ml-auto shrink-0">
+                        {sig.description}
+                      </span>
+                    </div>
+                    {sig.ai_summary && (
+                      <p className="text-xs text-muted-foreground pl-1 border-l-2 border-blue-200 ml-1">
+                        {sig.ai_summary}
+                      </p>
+                    )}
                   </div>
                 )
               })}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -132,6 +132,7 @@ export interface SignalItem {
   keyword: string
   description: string
   value: number | null
+  ai_summary: string | null
   detected_at: string
 }
 


### PR DESCRIPTION
## Summary
- SignalLog 新增 `ai_summary` 字段，支持 AI 自动分析摘要
- 实现 `auto_analyze_signals()`：采集后自动对 Top-N 信号调用 AI 分析
- 简报生成改为信号驱动：优先使用趋势信号作为输入，无信号时回退到 Top-20 关键词
- 前端信号卡片展示 AI 摘要（蓝色左边框样式）
- 新增 5 个 `auto_analyze` 测试用例（空列表、零限制、摘要更新、限制生效、schema 验证）

Closes #65

## Test plan
- [x] 20/20 signal tests passed
- [x] 218/218 full test suite passed
- [x] ruff + black checks passed
- [ ] CI pipeline passes