### PR TITLE
fix(ui): 默认展开分析、默认过滤、清空含分析数据

### DIFF
--- a/backend/app/routers/trends.py
+++ b/backend/app/routers/trends.py
@@ -111,11 +111,23 @@ async def list_platforms() -> PlatformsResponse:
     return PlatformsResponse(platforms=get_platforms())
 
 
-@router.delete("/all", summary="清空所有趋势数据", response_model=TrendsClearResponse)
+@router.delete(
+    "/all",
+    summary="清空所有数据（趋势+分析+简报+信号）",
+    response_model=TrendsClearResponse,
+)
 async def clear_all_trends(db: AsyncSession = Depends(get_db)) -> TrendsClearResponse:
-    """Delete every trend record from the database. This action is irreversible."""
+    """Delete all trend records, AI insights, daily briefs, and signal logs."""
     from sqlalchemy import delete as sql_delete
 
+    from app.models.ai_insight import AIInsight
+    from app.models.daily_brief import DailyBrief
+    from app.models.signal_log import SignalLog
+
     result = await db.execute(sql_delete(Trend))
+    deleted = result.rowcount
+    await db.execute(sql_delete(AIInsight))
+    await db.execute(sql_delete(DailyBrief))
+    await db.execute(sql_delete(SignalLog))
     await db.commit()
-    return TrendsClearResponse(deleted=result.rowcount)
+    return TrendsClearResponse(deleted=deleted)

--- a/frontend/app/deep-analysis/page.tsx
+++ b/frontend/app/deep-analysis/page.tsx
@@ -22,7 +22,7 @@ function formatTime(iso: string | null) {
 }
 
 function AnalysisCard({ item }: { item: DeepAnalysisResponse }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(true)
   const sentiment = sentimentConfig[item.deep_analysis.sentiment] ?? sentimentConfig.neutral
 
   return (

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -387,7 +387,7 @@ export default function TrendsPage() {
   const [activePlatform, setActivePlatform] = useState<string | null>(null)
   const [compareKeyword, setCompareKeyword] = useState<string | null>(null)
   const [allItems, setAllItems] = useState<Record<string, TrendItem[]>>({})
-  const [relevantOnly, setRelevantOnly] = useState(false)
+  const [relevantOnly, setRelevantOnly] = useState(true)
 
   useEffect(() => {
     api.trends


### PR DESCRIPTION
## Summary
- 深度分析页面：卡片默认展开详情（`expanded` 默认 `true`）
- 趋势列表：默认开启智能过滤（`relevantOnly` 默认 `true`）
- 清空数据按钮：同时删除 `ai_insights`、`daily_briefs`、`signal_logs` 表

## Test plan
- [x] ruff + black 通过
- [x] tsc --noEmit 通过