### PR TITLE
feat(email): 恢复邮件推送功能 + 设置页面显示配置状态 (#88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,13 @@ SEARCH_PROVIDER=bing
 # Network → any XHR request → copy the full "Cookie" request header value
 TIKTOK_COOKIE=
 
+# Email (optional — leave empty to disable email notifications)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+ALERT_EMAIL_TO=
+
 # Scheduler — global default (cron: every day at 06:00)
 COLLECT_CRON=0 6 * * *
 # Per-platform overrides (empty = use COLLECT_CRON)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,13 @@ class Settings(BaseSettings):
     relevance_filter_enabled: bool = True
     user_profile: str = ""
 
+    # Email
+    smtp_host: str = "smtp.gmail.com"
+    smtp_port: int = 587
+    smtp_user: str = ""
+    smtp_password: str = ""
+    alert_email_to: str = ""
+
     # TikTok
     tiktok_cookie: str = ""  # Paste browser Cookie header from ads.tiktok.com session
 

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -26,4 +26,11 @@ async def get_system_config() -> dict:
         "scheduler": {
             "collect_cron": settings.collect_cron,
         },
+        "email": {
+            "configured": bool(
+                settings.smtp_user and settings.smtp_password and settings.alert_email_to
+            ),
+            "smtp_host": settings.smtp_host,
+            "recipient": settings.alert_email_to or None,
+        },
     }

--- a/backend/app/services/brief.py
+++ b/backend/app/services/brief.py
@@ -12,6 +12,7 @@ from app.ai.base import ChatMessage
 from app.ai.factory import LLMFactory
 from app.config import settings
 from app.models.daily_brief import DailyBrief
+from app.services.email import send_email
 from app.services.signals import get_recent_signals
 from app.services.trends import get_top_trends
 
@@ -87,6 +88,12 @@ async def generate_daily_brief(db: AsyncSession) -> DailyBrief:
 
     await db.commit()
     await db.refresh(brief)
+
+    # Send email notification with the brief content
+    await send_email(
+        subject=f"TrendTracker 每日简报 — {today}",
+        body=content,
+    )
 
     return brief
 

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,46 @@
+"""Async email sender using stdlib smtplib via asyncio.to_thread."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _send_sync(subject: str, body: str, to: str) -> None:
+    """Synchronous SMTP send — runs in a thread pool."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = settings.smtp_user
+    msg["To"] = to
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+
+    with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=15) as server:
+        server.ehlo()
+        server.starttls()
+        server.login(settings.smtp_user, settings.smtp_password)
+        server.sendmail(settings.smtp_user, [to], msg.as_string())
+
+
+async def send_email(subject: str, body: str, to: str | None = None) -> bool:
+    """Send an email; returns True on success, False if skipped or failed.
+
+    Skips silently when SMTP credentials are not configured.
+    """
+    recipient = to or settings.alert_email_to
+    if not all([settings.smtp_user, settings.smtp_password, recipient]):
+        logger.info("send_email: SMTP not configured, skipping")
+        return False
+    try:
+        await asyncio.to_thread(_send_sync, subject, body, recipient)
+        logger.info("send_email: sent '%s' to %s", subject, recipient)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.error("send_email: failed — %s", exc)
+        return False

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import { Settings, RefreshCw, Trash2, CheckCircle, XCircle, Clock } from "lucide-react"
+import { Settings, RefreshCw, Trash2, CheckCircle, XCircle, Clock, Mail } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -244,6 +244,47 @@ export default function SettingsPage() {
                 <span className="text-muted-foreground">API Key</span>
                 <StatusBadge ok={config.ai.configured} />
               </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">无法加载配置</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 邮件推送 */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Mail className="w-4 h-4" />
+            邮件推送
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <Skeleton className="h-16 w-full" />
+          ) : config ? (
+            <div className="space-y-3">
+              <div className="divide-y rounded-md border text-sm">
+                <div className="flex items-center justify-between px-3 py-2.5">
+                  <span className="text-muted-foreground">SMTP 配置</span>
+                  <StatusBadge ok={config.email.configured} />
+                </div>
+                <div className="flex items-center justify-between px-3 py-2.5">
+                  <span className="text-muted-foreground">SMTP 服务器</span>
+                  <span className="font-mono text-xs">{config.email.smtp_host}</span>
+                </div>
+                <div className="flex items-center justify-between px-3 py-2.5">
+                  <span className="text-muted-foreground">收件邮箱</span>
+                  <span className="font-mono text-xs">
+                    {config.email.recipient ?? "未设置"}
+                  </span>
+                </div>
+              </div>
+              {!config.email.configured && (
+                <p className="text-xs text-muted-foreground">
+                  在 .env 中配置 SMTP_USER、SMTP_PASSWORD、ALERT_EMAIL_TO 即可启用每日简报邮件推送
+                </p>
+              )}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">无法加载配置</p>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -107,6 +107,7 @@ export interface SystemConfig {
   ai: { provider: string; configured: boolean }
   tiktok: { configured: boolean }
   scheduler: { collect_cron: string }
+  email: { configured: boolean; smtp_host: string; recipient: string | null }
 }
 
 export interface SchedulerStatus {


### PR DESCRIPTION
## Summary
- 恢复 `email.py` 异步邮件发送服务（从 git 历史恢复）
- 简报生成后自动调用 `send_email()`，SMTP 未配置时静默跳过
- 系统设置页面新增邮件推送配置卡片，显示 SMTP 状态/服务器/收件邮箱

Closes #88

## Test plan
- [ ] 配置 SMTP 后手动触发简报，确认收到邮件
- [ ] 不配置 SMTP，确认简报正常生成不报错
- [ ] 打开设置页面，确认邮件推送卡片正确显示配置状态