### PR TITLE
feat(settings): 信息源开关，控制采集与展示 (#100)

### DIFF
--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from app.config import settings
 from app.services.deep_analysis import get_show_business, set_show_business
+from app.services.platform_state import get_all_platform_states, set_platform_enabled
 
 router = APIRouter()
 
@@ -38,7 +39,20 @@ async def get_system_config() -> dict:
         "deep_analysis": {
             "show_business": get_show_business(),
         },
+        "platforms": get_all_platform_states(),
     }
+
+
+class PlatformToggleRequest(BaseModel):
+    platform: str
+    enabled: bool
+
+
+@router.put("/platforms", summary="切换平台信息源开关")
+async def toggle_platform(body: PlatformToggleRequest) -> dict:
+    """Enable or disable a platform data source."""
+    set_platform_enabled(body.platform, body.enabled)
+    return {"platform": body.platform, "enabled": body.enabled}
 
 
 class ShowBusinessRequest(BaseModel):

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -124,8 +124,14 @@ async def run_all_collectors(
 
     Returns a dict with ``status`` and ``records_count``.
     """
+    from app.services.platform_state import get_enabled_platforms
+
     if platforms is None:
-        platforms = registry.list_platforms()
+        platforms = get_enabled_platforms()
+    else:
+        # Even when explicit platforms are given, respect the enabled state
+        enabled = set(get_enabled_platforms())
+        platforms = [p for p in platforms if p in enabled]
 
     # Current hour bucket (naive UTC, matching DB storage)
     now = datetime.now(timezone.utc).replace(tzinfo=None)

--- a/backend/app/services/platform_state.py
+++ b/backend/app/services/platform_state.py
@@ -1,0 +1,48 @@
+"""Runtime platform enable/disable state.
+
+All registered platforms are enabled by default. Toggling a platform off
+excludes it from scheduled collection, manual collection, and all trend
+queries (dashboard, trends list, heatmap, velocity).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.collectors.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# None means "use default" (all enabled).  Once set, this overrides.
+_disabled_platforms: set[str] = set()
+
+
+def get_enabled_platforms() -> list[str]:
+    """Return the list of currently enabled platform slugs."""
+    all_platforms = registry.list_platforms()
+    return [p for p in all_platforms if p not in _disabled_platforms]
+
+
+def get_disabled_platforms() -> set[str]:
+    """Return the set of disabled platform slugs."""
+    return set(_disabled_platforms)
+
+
+def is_platform_enabled(slug: str) -> bool:
+    """Check whether a specific platform is enabled."""
+    return slug not in _disabled_platforms
+
+
+def set_platform_enabled(slug: str, enabled: bool) -> None:
+    """Enable or disable a platform at runtime."""
+    if enabled:
+        _disabled_platforms.discard(slug)
+        logger.info("Platform '%s' enabled", slug)
+    else:
+        _disabled_platforms.add(slug)
+        logger.info("Platform '%s' disabled", slug)
+
+
+def get_all_platform_states() -> dict[str, bool]:
+    """Return {slug: enabled} for all registered platforms."""
+    return {p: p not in _disabled_platforms for p in registry.list_platforms()}

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -57,6 +57,15 @@ async def collect_trends_job(platforms: list[str] | None = None) -> None:
     Args:
         platforms: optional list of platform slugs. None = all platforms.
     """
+    # Filter by enabled platforms at runtime
+    from app.services.platform_state import is_platform_enabled
+
+    if platforms:
+        platforms = [p for p in platforms if is_platform_enabled(p)]
+        if not platforms:
+            logger.info("collect_trends_job: all requested platforms are disabled, skipping")
+            return
+
     label = ",".join(platforms) if platforms else "all"
     logger.info("collect_trends_job[%s]: starting", label)
     try:

--- a/backend/app/services/signals.py
+++ b/backend/app/services/signals.py
@@ -229,10 +229,13 @@ async def _detect_heat_surges(db: AsyncSession, now: datetime) -> list[SignalLog
 
 async def get_recent_signals(db: AsyncSession, hours: int = 24, limit: int = 50) -> list[SignalLog]:
     """Return most recent signals within the given time window."""
+    from app.services.platform_state import get_enabled_platforms
+
     since = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=hours)
+    enabled = get_enabled_platforms()
     result = await db.execute(
         select(SignalLog)
-        .where(SignalLog.detected_at >= since)
+        .where(SignalLog.detected_at >= since, SignalLog.platform.in_(enabled))
         .order_by(SignalLog.detected_at.desc())
         .limit(limit)
     )

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -8,8 +8,8 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.collectors.registry import registry
 from app.models.trend import Trend
+from app.services.platform_state import get_enabled_platforms
 
 # ---------------------------------------------------------------------------
 # Simple counts
@@ -102,7 +102,8 @@ async def get_trends(
     since = now - timedelta(hours=24)
     offset = (page - 1) * page_size
 
-    base_filter = Trend.collected_at >= since
+    enabled = get_enabled_platforms()
+    base_filter = (Trend.collected_at >= since) & (Trend.platform.in_(enabled))
     if platform:
         base_filter = base_filter & (Trend.platform == platform)
 
@@ -179,8 +180,9 @@ async def get_top_trends(
     """
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     since = now - timedelta(hours=24)
+    enabled = get_enabled_platforms()
 
-    stmt = select(Trend).where(Trend.collected_at >= since)
+    stmt = select(Trend).where(Trend.collected_at >= since, Trend.platform.in_(enabled))
     if relevant_only:
         stmt = stmt.where(Trend.relevance_label == "relevant")
     result = await db.execute(stmt.order_by(Trend.collected_at.desc()))
@@ -246,9 +248,12 @@ async def get_top_trends_by_platform(db: AsyncSession, limit: int = 10) -> dict[
     """Return top-N keywords per platform, each scored with per-platform normalization."""
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     since = now - timedelta(hours=24)
+    enabled = get_enabled_platforms()
 
     result = await db.execute(
-        select(Trend).where(Trend.collected_at >= since).order_by(Trend.collected_at.desc())
+        select(Trend)
+        .where(Trend.collected_at >= since, Trend.platform.in_(enabled))
+        .order_by(Trend.collected_at.desc())
     )
     rows = result.scalars().all()
 
@@ -293,8 +298,8 @@ async def get_top_trends_by_platform(db: AsyncSession, limit: int = 10) -> dict[
 
 
 def get_platforms() -> list[str]:
-    """Return all registered platform slugs."""
-    return registry.list_platforms()
+    """Return enabled platform slugs."""
+    return get_enabled_platforms()
 
 
 # ---------------------------------------------------------------------------
@@ -322,13 +327,14 @@ async def get_keyword_velocity(
     t1_start = t0_start + period
     t2_start = t1_start + period
 
+    enabled = get_enabled_platforms()
     base = select(
         Trend.platform,
         Trend.keyword,
         Trend.heat_score,
         Trend.rank,
         Trend.collected_at,
-    ).where(Trend.collected_at >= t0_start)
+    ).where(Trend.collected_at >= t0_start, Trend.platform.in_(enabled))
     if platform:
         base = base.where(Trend.platform == platform)
 
@@ -410,9 +416,11 @@ async def get_heatmap(db: AsyncSession) -> dict:
     ]
     slot_index: dict[str, int] = {s.strftime("%Y-%m-%d %H"): i for i, s in enumerate(slots)}
 
+    enabled = get_enabled_platforms()
     result = await db.execute(
         select(Trend.platform, Trend.collected_at, Trend.heat_score).where(
-            Trend.collected_at >= since
+            Trend.collected_at >= since,
+            Trend.platform.in_(enabled),
         )
     )
     rows = result.all()

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -80,6 +80,8 @@ export default function DashboardPage() {
   const [signals, setSignals] = useState<SignalItem[]>([])
   const [signalsLoading, setSignalsLoading] = useState(true)
 
+  const [enabledPlatforms, setEnabledPlatforms] = useState<Set<string> | null>(null)
+
   useEffect(() => {
     api.health().then(setHealth).catch(() => setHealthError(true))
 
@@ -92,6 +94,17 @@ export default function DashboardPage() {
       .latestBrief()
       .then(setBrief)
       .catch(() => setBrief(null))
+
+    api.system
+      .config()
+      .then((cfg) => {
+        if (cfg.platforms) {
+          setEnabledPlatforms(
+            new Set(Object.entries(cfg.platforms).filter(([, v]) => v).map(([k]) => k))
+          )
+        }
+      })
+      .catch(() => {})
 
     api.trends
       .topByPlatform(10)

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import { Settings, RefreshCw, Trash2, CheckCircle, XCircle, Clock, Mail, Newspaper, Briefcase } from "lucide-react"
+import { Settings, RefreshCw, Trash2, CheckCircle, XCircle, Clock, Mail, Newspaper, Briefcase, Radio } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -107,6 +108,19 @@ export default function SettingsPage() {
     }
   }
 
+  const handleTogglePlatform = async (platform: string, enabled: boolean) => {
+    if (!config) return
+    try {
+      await api.system.togglePlatform(platform, enabled)
+      setConfig({
+        ...config,
+        platforms: { ...config.platforms, [platform]: enabled },
+      })
+    } catch {
+      /* ignore */
+    }
+  }
+
   const jobNameMap: Record<string, string> = {
     collect_trends: "采集热词",
     daily_brief: "生成日报",
@@ -195,6 +209,56 @@ export default function SettingsPage() {
             </>
           ) : (
             <p className="text-sm text-muted-foreground">无法获取调度器状态，后端可能未启动</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 信息源开关 */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Radio className="w-4 h-4" />
+            信息源管理
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">
+            关闭的信息源不会参与采集，仪表盘和趋势列表中也不会显示对应数据
+          </p>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
+            </div>
+          ) : config ? (
+            <div className="divide-y rounded-md border text-sm">
+              {PLATFORMS.map((slug) => {
+                const meta = getPlatformMeta(slug)
+                const enabled = config.platforms?.[slug] ?? true
+                const needsConfig = slug === "tiktok" && !config.tiktok.configured
+                return (
+                  <div key={slug} className="flex items-center justify-between px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-block w-2 h-2 rounded-full"
+                        style={{ backgroundColor: enabled ? meta.color : "#d1d5db" }}
+                      />
+                      <span className={`font-medium ${!enabled ? "text-muted-foreground" : ""}`}>
+                        {meta.displayName}
+                      </span>
+                      {needsConfig && (
+                        <span className="text-xs text-amber-500">需配置 TIKTOK_COOKIE</span>
+                      )}
+                    </div>
+                    <Switch
+                      checked={enabled}
+                      onCheckedChange={(checked) => handleTogglePlatform(slug, checked)}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">无法加载配置</p>
           )}
         </CardContent>
       </Card>

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -377,7 +377,7 @@ function PlatformCard({
 // Main Page
 // ---------------------------------------------------------------------------
 
-const PLATFORMS = Object.keys(PLATFORM_CONFIG)
+const ALL_PLATFORMS = Object.keys(PLATFORM_CONFIG)
 
 export default function TrendsPage() {
   const [refreshKey, setRefreshKey] = useState(0)
@@ -388,6 +388,21 @@ export default function TrendsPage() {
   const [compareKeyword, setCompareKeyword] = useState<string | null>(null)
   const [allItems, setAllItems] = useState<Record<string, TrendItem[]>>({})
   const [relevantOnly, setRelevantOnly] = useState(true)
+  const [enabledPlatforms, setEnabledPlatforms] = useState<string[]>(ALL_PLATFORMS)
+
+  useEffect(() => {
+    api.system
+      .config()
+      .then((cfg) => {
+        if (cfg.platforms) {
+          const enabled = Object.entries(cfg.platforms)
+            .filter(([, v]) => v)
+            .map(([k]) => k)
+          setEnabledPlatforms(enabled)
+        }
+      })
+      .catch(() => {})
+  }, [])
 
   useEffect(() => {
     api.trends
@@ -420,7 +435,7 @@ export default function TrendsPage() {
     setCompareKeyword((prev) => (prev === keyword ? null : keyword))
   }, [])
 
-  const visiblePlatforms = activePlatform ? [activePlatform] : PLATFORMS
+  const visiblePlatforms = activePlatform ? [activePlatform] : enabledPlatforms
 
   return (
     <div className="p-6 space-y-6">
@@ -482,7 +497,7 @@ export default function TrendsPage() {
           >
             全部
           </Badge>
-          {PLATFORMS.map((slug) => {
+          {enabledPlatforms.map((slug) => {
             const meta = getPlatformMeta(slug)
             return (
               <Badge

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -111,6 +111,7 @@ export interface SystemConfig {
   scheduler: { collect_cron: string }
   email: { configured: boolean; smtp_host: string; recipient: string | null }
   deep_analysis: { show_business: boolean }
+  platforms: Record<string, boolean>
 }
 
 export interface SchedulerStatus {
@@ -187,6 +188,11 @@ export const api = {
       request<{ show_business: boolean }>("/api/v1/system/deep-analysis-mode", {
         method: "PUT",
         body: JSON.stringify({ show }),
+      }),
+    togglePlatform: (platform: string, enabled: boolean) =>
+      request<{ platform: string; enabled: boolean }>("/api/v1/system/platforms", {
+        method: "PUT",
+        body: JSON.stringify({ platform, enabled }),
       }),
   },
   signals: {


### PR DESCRIPTION
## Summary
- 设置页新增「信息源管理」卡片，每个平台有独立 Switch 开关
- 关闭的平台不参与定时/手动采集
- 仪表盘、趋势列表、热力图、动量、信号等所有查询自动过滤已禁用平台
- 后端新增 platform_state 模块（运行时状态） + PUT /api/v1/system/platforms 接口

## Test plan
- [x] 232 backend tests passed
- [x] Frontend build success
- [ ] 手动验证：关闭某平台后，采集跳过该平台，仪表盘/趋势列表不显示

Closes #100