### PR TITLE
feat(collector): SSE 实时推送采集管线进度

### DIFF
--- a/backend/app/routers/collector.py
+++ b/backend/app/routers/collector.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.schemas.collector import CollectorRunResponse
-from app.services.collector import run_all_collectors
+from app.services.collector import run_all_collectors, run_all_collectors_stream
 
 router = APIRouter()
 
@@ -21,3 +24,30 @@ async def collector_run(
     platform_list = [p.strip() for p in platforms.split(",") if p.strip()] if platforms else None
     result = await run_all_collectors(db, platforms=platform_list)
     return CollectorRunResponse(**result)
+
+
+@router.post("/run-stream", summary="手动触发数据采集（SSE 实时进度）")
+async def collector_run_stream(
+    platforms: str | None = Query(None, description="平台列表（逗号分隔），为空则采集全部平台"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Trigger collectors with SSE progress streaming.
+
+    Returns a stream of ``text/event-stream`` events.  Each event is a JSON
+    object with at least ``stage`` and ``message`` fields.
+    """
+    platform_list = [p.strip() for p in platforms.split(",") if p.strip()] if platforms else None
+
+    async def event_generator():
+        async for event in run_all_collectors_stream(db, platforms=platform_list):
+            yield f"data: {json.dumps(event, ensure_ascii=False, default=str)}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -199,3 +199,146 @@ async def run_all_collectors(
         await auto_deep_analyze(db, relevance_scores)
 
     return {"status": "ok", "records_count": total_records, "platforms": platform_results}
+
+
+# ---------------------------------------------------------------------------
+# Streaming (SSE) variant — yields progress events as JSON dicts
+# ---------------------------------------------------------------------------
+
+
+async def run_all_collectors_stream(
+    db: AsyncSession,
+    platforms: list[str] | None = None,
+):
+    """Async generator that yields progress dicts for each pipeline stage.
+
+    Each yielded dict has at least ``{"stage": ..., "message": ...}``.
+    The final event has ``"stage": "done"``.
+    """
+    from app.services.platform_state import get_enabled_platforms
+
+    if platforms is None:
+        platforms = get_enabled_platforms()
+    else:
+        enabled = set(get_enabled_platforms())
+        platforms = [p for p in platforms if p in enabled]
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    hour_start = now.replace(minute=0, second=0, microsecond=0)
+    hour_end = hour_start + timedelta(hours=1)
+
+    # --- Stage: collecting (per-platform) ---
+    yield {"stage": "collecting", "message": f"开始采集 {len(platforms)} 个平台..."}
+
+    # Collect platforms concurrently but report each result as it arrives
+    futures = [asyncio.ensure_future(_collect_one(slug)) for slug in platforms]
+    total_records = 0
+    platform_results = []
+
+    for coro in asyncio.as_completed(futures):
+        platform_slug, records, error = await coro
+        platform_results.append({"platform": platform_slug, "count": len(records), "error": error})
+
+        if error:
+            yield {
+                "stage": "collecting",
+                "platform": platform_slug,
+                "count": 0,
+                "error": error,
+                "message": f"{platform_slug} 采集失败: {error}",
+            }
+        else:
+            yield {
+                "stage": "collecting",
+                "platform": platform_slug,
+                "count": len(records),
+                "message": f"{platform_slug} 采集完成 +{len(records)} 条",
+            }
+
+        if records:
+            await db.execute(
+                delete(Trend).where(
+                    Trend.platform == platform_slug,
+                    Trend.collected_at >= hour_start,
+                    Trend.collected_at < hour_end,
+                )
+            )
+            platform_id = await _ensure_platform(db, platform_slug)
+            for rec in records:
+                db.add(
+                    Trend(
+                        platform_id=platform_id,
+                        platform=rec["platform"],
+                        keyword=rec["keyword"],
+                        rank=rec.get("rank"),
+                        heat_score=rec.get("heat_score"),
+                        url=rec.get("url"),
+                        collected_at=rec["collected_at"],
+                    )
+                )
+            total_records += len(records)
+
+    await db.commit()
+    yield {
+        "stage": "collected",
+        "records_count": total_records,
+        "platforms": platform_results,
+        "message": f"采集完成，共 {total_records} 条",
+    }
+
+    # --- Stage: scoring ---
+    from app.config import settings as app_settings
+
+    relevance_scores: dict[str, dict] = {}
+    if app_settings.relevance_filter_enabled and total_records > 0:
+        yield {"stage": "scoring", "message": "AI 相关性评分中..."}
+        relevance_scores = await _score_new_keywords(db, hour_start, hour_end)
+        relevant_count = sum(1 for v in relevance_scores.values() if v.get("label") == "relevant")
+        yield {
+            "stage": "scoring",
+            "total": len(relevance_scores),
+            "relevant": relevant_count,
+            "message": f"评分完成: {relevant_count}/{len(relevance_scores)} 条相关",
+        }
+
+    # --- Stage: signals ---
+    from app.services.signals import auto_analyze_signals, detect_signals
+
+    yield {"stage": "signals", "message": "信号检测中..."}
+    signals = await detect_signals(db)
+    yield {
+        "stage": "signals",
+        "count": len(signals),
+        "message": f"检测到 {len(signals)} 个信号",
+    }
+
+    from app.config import settings
+
+    if signals and settings.signal_auto_analyze_limit > 0:
+        yield {"stage": "signals", "message": "AI 分析信号中..."}
+        analyzed = await auto_analyze_signals(db, signals, limit=settings.signal_auto_analyze_limit)
+        yield {
+            "stage": "signals",
+            "analyzed": analyzed,
+            "message": f"已分析 {analyzed} 个信号",
+        }
+
+    # --- Stage: deep_analysis ---
+    if relevance_scores and settings.deep_analysis_auto_max > 0:
+        from app.services.deep_analysis import auto_deep_analyze
+
+        yield {"stage": "deep_analysis", "message": "深度分析中..."}
+        deep_results = await auto_deep_analyze(db, relevance_scores)
+        yield {
+            "stage": "deep_analysis",
+            "count": len(deep_results),
+            "message": f"深度分析完成: {len(deep_results)} 个关键词",
+        }
+
+    # --- Done ---
+    yield {
+        "stage": "done",
+        "records_count": total_records,
+        "platforms": platform_results,
+        "message": "全部完成",
+    }

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -17,7 +17,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { api, type SystemConfig, type SchedulerStatus, type CollectorRunResponse } from "@/lib/api"
+import { api, type SystemConfig, type SchedulerStatus } from "@/lib/api"
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"
+
+interface CollectEvent {
+  stage: string
+  message: string
+  platform?: string
+  count?: number
+  error?: string
+  records_count?: number
+  platforms?: { platform: string; count: number; error: string | null }[]
+  total?: number
+  relevant?: number
+  analyzed?: number
+}
 import { getPlatformMeta } from "@/lib/platform-config"
 
 const PLATFORMS = ["weibo", "google", "tiktok"] as const
@@ -41,7 +56,8 @@ export default function SettingsPage() {
   const [scheduler, setScheduler] = useState<SchedulerStatus | null>(null)
   const [platformLastPull, setPlatformLastPull] = useState<Record<string, string>>({})
   const [collecting, setCollecting] = useState(false)
-  const [collectResult, setCollectResult] = useState<CollectorRunResponse | null>(null)
+  const [collectLogs, setCollectLogs] = useState<CollectEvent[]>([])
+  const [collectDone, setCollectDone] = useState(false)
   const [clearing, setClearing] = useState(false)
   const [clearResult, setClearResult] = useState<{ deleted: number } | null>(null)
   const [loading, setLoading] = useState(true)
@@ -75,11 +91,43 @@ export default function SettingsPage() {
 
   const handleCollect = async () => {
     setCollecting(true)
-    setCollectResult(null)
+    setCollectLogs([])
+    setCollectDone(false)
     try {
-      const result = await api.post<CollectorRunResponse>("/api/v1/collector/run", {})
-      setCollectResult(result)
+      const res = await fetch(`${BASE_URL}/api/v1/collector/run-stream`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+      if (!res.ok || !res.body) {
+        setCollectLogs([{ stage: "error", message: `请求失败: ${res.status}` }])
+        return
+      }
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ""
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n\n")
+        buffer = lines.pop() ?? ""
+        for (const chunk of lines) {
+          const dataLine = chunk.replace(/^data: /, "").trim()
+          if (!dataLine) continue
+          try {
+            const event: CollectEvent = JSON.parse(dataLine)
+            setCollectLogs((prev) => [...prev, event])
+            if (event.stage === "done") {
+              setCollectDone(true)
+            }
+          } catch {
+            // ignore malformed events
+          }
+        }
+      }
       await load()
+    } catch {
+      setCollectLogs((prev) => [...prev, { stage: "error", message: "连接失败" }])
     } finally {
       setCollecting(false)
     }
@@ -179,7 +227,7 @@ export default function SettingsPage() {
                 ))}
               </div>
 
-              <div className="flex items-center gap-3">
+              <div className="space-y-3">
                 <Button
                   size="sm"
                   variant="outline"
@@ -190,18 +238,30 @@ export default function SettingsPage() {
                   <RefreshCw className={`w-4 h-4 ${collecting ? "animate-spin" : ""}`} />
                   立即采集
                 </Button>
-                {collectResult && (
-                  <div className="flex items-center gap-2 text-sm">
-                    <span className="text-muted-foreground">采集完成，共 {collectResult.records_count} 条</span>
-                    {collectResult.platforms.map((p) => (
-                      <Badge
-                        key={p.platform}
-                        variant={p.error ? "destructive" : "secondary"}
-                        className="text-xs"
-                      >
-                        {getPlatformMeta(p.platform).displayName}
-                        {p.error ? " ✗" : ` +${p.count}`}
-                      </Badge>
+                {collectLogs.length > 0 && (
+                  <div className="rounded-md border bg-muted/30 p-3 space-y-1.5 text-sm max-h-60 overflow-y-auto">
+                    {collectLogs.map((log, i) => (
+                      <div key={i} className="flex items-start gap-2">
+                        <span className="shrink-0 mt-0.5">
+                          {log.stage === "done" ? (
+                            <CheckCircle className="w-3.5 h-3.5 text-green-500" />
+                          ) : log.stage === "error" || log.error ? (
+                            <XCircle className="w-3.5 h-3.5 text-destructive" />
+                          ) : collectDone || i < collectLogs.length - 1 ? (
+                            <CheckCircle className="w-3.5 h-3.5 text-muted-foreground" />
+                          ) : (
+                            <RefreshCw className="w-3.5 h-3.5 text-blue-500 animate-spin" />
+                          )}
+                        </span>
+                        <span className={log.stage === "done" ? "font-medium text-green-600" : log.error ? "text-destructive" : "text-muted-foreground"}>
+                          {log.message}
+                        </span>
+                        {log.stage === "collecting" && log.platform && !log.error && (
+                          <Badge variant="secondary" className="text-xs ml-auto">
+                            {getPlatformMeta(log.platform).displayName} +{log.count}
+                          </Badge>
+                        )}
+                      </div>
                     ))}
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- 新增 `POST /api/v1/collector/run-stream` SSE 端点，实时推送采集管线各阶段进度
- 前端设置页"立即采集"改用 SSE 流式消费，实时显示进度日志（采集/评分/信号/深度分析）
- 原有 `/collector/run` 同步端点保持不变，向后兼容

## Test plan
- [x] 232 backend tests pass
- [x] Frontend build clean
- [ ] 手动点击"立即采集"验证 SSE 进度实时显示
- [ ] 验证各阶段（采集/评分/信号/深度分析）进度消息正确推送

Closes #102
