### PR TITLE
fix(search): 空结果重试 + Provider 自动降级

### DIFF
--- a/backend/app/search/base.py
+++ b/backend/app/search/base.py
@@ -31,20 +31,35 @@ class BaseSearchProvider(ABC):
     async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
         """Search with exponential backoff retry.
 
-        Subclasses implement :meth:`_do_search` instead of overriding this.
+        Retries on both exceptions AND empty results (may indicate silent
+        rate-limiting or transient failures).  Subclasses implement
+        :meth:`_do_search` instead of overriding this.
         """
         last_exc: Exception | None = None
         for attempt in range(MAX_RETRIES):
             try:
                 results = await self._do_search(query, max_results)
-                if attempt > 0:
-                    logger.info(
-                        "%s search succeeded on attempt %d for '%s'",
-                        self.provider_name,
-                        attempt + 1,
-                        query,
-                    )
-                return results
+                if results:
+                    if attempt > 0:
+                        logger.info(
+                            "%s search succeeded on attempt %d for '%s' (%d results)",
+                            self.provider_name,
+                            attempt + 1,
+                            query,
+                            len(results),
+                        )
+                    return results
+                # Empty results — treat as transient failure, retry
+                delay = BASE_DELAY * (2**attempt)
+                logger.warning(
+                    "%s search returned 0 results on attempt %d/%d for '%s'" " — retrying in %.1fs",
+                    self.provider_name,
+                    attempt + 1,
+                    MAX_RETRIES,
+                    query,
+                    delay,
+                )
+                await asyncio.sleep(delay)
             except Exception as exc:  # noqa: BLE001
                 last_exc = exc
                 delay = BASE_DELAY * (2**attempt)
@@ -59,13 +74,21 @@ class BaseSearchProvider(ABC):
                 )
                 await asyncio.sleep(delay)
 
-        logger.error(
-            "%s search failed after %d attempts for '%s': %s",
-            self.provider_name,
-            MAX_RETRIES,
-            query,
-            last_exc,
-        )
+        if last_exc:
+            logger.error(
+                "%s search failed after %d attempts for '%s': %s",
+                self.provider_name,
+                MAX_RETRIES,
+                query,
+                last_exc,
+            )
+        else:
+            logger.error(
+                "%s search returned 0 results after %d attempts for '%s'",
+                self.provider_name,
+                MAX_RETRIES,
+                query,
+            )
         return []
 
     @abstractmethod

--- a/backend/app/search/factory.py
+++ b/backend/app/search/factory.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
 from app.config import settings
-from app.search.base import BaseSearchProvider
+from app.search.base import BaseSearchProvider, SearchResult
+
+logger = logging.getLogger(__name__)
 
 
 class SearchFactory:
@@ -19,18 +23,74 @@ class SearchFactory:
         "bing": "app.search.bing.BingProvider",
     }
 
+    # Fallback order — primary provider is tried first, then these in order.
+    _FALLBACK_ORDER: list[str] = ["bing", "duckduckgo", "google"]
+
     @classmethod
     def create(cls, provider_name: str | None = None) -> BaseSearchProvider:
         """Return an instance of the configured search provider."""
         name = (provider_name or settings.search_provider).lower()
+        return cls._instantiate(name)
+
+    @classmethod
+    def _instantiate(cls, name: str) -> BaseSearchProvider:
         dotted_path = cls._PROVIDERS.get(name)
         if dotted_path is None:
             available = ", ".join(sorted(cls._PROVIDERS.keys()))
             raise ValueError(f"Unknown search provider '{name}'. Available: {available}.")
 
-        module_path, class_name = dotted_path.rsplit(".", 1)
         import importlib
 
+        module_path, class_name = dotted_path.rsplit(".", 1)
         module = importlib.import_module(module_path)
         provider_cls = getattr(module, class_name)
         return provider_cls()
+
+    @classmethod
+    def get_fallback_chain(cls) -> list[str]:
+        """Return ordered fallback list: primary provider first, then others."""
+        primary = settings.search_provider.lower()
+        chain = [primary]
+        for name in cls._FALLBACK_ORDER:
+            if name != primary:
+                chain.append(name)
+        return chain
+
+    @classmethod
+    async def search_with_fallback(cls, query: str, max_results: int = 5) -> list[SearchResult]:
+        """Try each provider in fallback chain until one returns results.
+
+        Each provider's own retry logic (3 attempts with backoff) is exhausted
+        before moving to the next provider.
+        """
+        chain = cls.get_fallback_chain()
+        for i, name in enumerate(chain):
+            try:
+                provider = cls._instantiate(name)
+                results = await provider.search(query, max_results)
+                if results:
+                    if i > 0:
+                        logger.info(
+                            "Fallback search succeeded with %s for '%s' (%d results)",
+                            name,
+                            query,
+                            len(results),
+                        )
+                    return results
+                logger.warning(
+                    "Provider %s returned 0 results for '%s', trying next fallback",
+                    name,
+                    query,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Provider %s crashed for '%s', trying next fallback",
+                    name,
+                    query,
+                )
+        logger.error(
+            "All search providers failed for '%s' (chain: %s)",
+            query,
+            " → ".join(chain),
+        )
+        return []

--- a/backend/app/services/deep_analysis.py
+++ b/backend/app/services/deep_analysis.py
@@ -213,11 +213,17 @@ async def list_deep_analyses(db: AsyncSession, limit: int = 50) -> list[dict]:
 
 
 async def _web_search(keyword: str) -> list[SearchResult]:
-    """Search the web for context about a keyword."""
+    """Search the web for context about a keyword.
+
+    Uses fallback chain: if the primary provider returns 0 results (after its
+    own retries), the next provider in the chain is tried automatically.
+    """
     try:
-        provider = SearchFactory.create()
-        results = await provider.search(keyword, max_results=5)
-        logger.info("Web search for '%s': got %d results", keyword, len(results))
+        results = await SearchFactory.search_with_fallback(keyword, max_results=5)
+        if results:
+            logger.info("Web search for '%s': got %d results", keyword, len(results))
+        else:
+            logger.warning("Web search for '%s': all providers returned 0 results", keyword)
         return results
     except Exception:
         logger.exception("Web search failed for '%s'", keyword)

--- a/backend/tests/test_deep_analysis.py
+++ b/backend/tests/test_deep_analysis.py
@@ -14,18 +14,21 @@ async def test_web_search_returns_list(monkeypatch):
     """Web search should return a list (even on failure)."""
     from app.search.base import SearchResult
 
-    class MockProvider:
-        provider_name = "mock"
+    mock_results = [
+        SearchResult(title="T1", snippet="S1", url="https://a.com"),
+        SearchResult(title="T2", snippet="S2", url="https://b.com"),
+    ]
 
-        async def search(self, query, max_results=5):
-            return [
-                SearchResult(title="T1", snippet="S1", url="https://a.com"),
-                SearchResult(title="T2", snippet="S2", url="https://b.com"),
-            ]
+    async def mock_search_with_fallback(query, max_results=5):
+        return mock_results
 
     monkeypatch.setattr(
         "app.services.deep_analysis.SearchFactory",
-        type("MockFactory", (), {"create": classmethod(lambda cls: MockProvider())}),
+        type(
+            "MockFactory",
+            (),
+            {"search_with_fallback": staticmethod(mock_search_with_fallback)},
+        ),
     )
 
     results = await _web_search("AI芯片")
@@ -37,15 +40,16 @@ async def test_web_search_returns_list(monkeypatch):
 async def test_web_search_failure_returns_empty(monkeypatch):
     """On search failure, should return empty list."""
 
-    class FailProvider:
-        provider_name = "fail"
-
-        async def search(self, query, max_results=5):
-            raise RuntimeError("Search down")
+    async def mock_search_with_fallback(query, max_results=5):
+        raise RuntimeError("Search down")
 
     monkeypatch.setattr(
         "app.services.deep_analysis.SearchFactory",
-        type("MockFactory", (), {"create": classmethod(lambda cls: FailProvider())}),
+        type(
+            "MockFactory",
+            (),
+            {"search_with_fallback": staticmethod(mock_search_with_fallback)},
+        ),
     )
 
     results = await _web_search("AI芯片")


### PR DESCRIPTION
## Summary
- 搜索空结果现在会触发重试（之前只有异常才重试），解决静默限流/HTML变化导致的 0 结果问题
- 新增 Provider 自动降级链：主引擎失败后自动尝试备选引擎（如 Bing -> DuckDuckGo -> Google）
- 日志区分"空结果重试"和"异常重试"，方便排查

## Test plan
- [x] 16 search/deep_analysis 测试通过
- [ ] 全量 232 测试通过（CI 中）
- [ ] 手动验证：深度分析关键词时搜索结果命中率提升

Closes #105
