### PR TITLE
fix(ci): use peter-evans/create-pull-request for changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,17 +81,11 @@ jobs:
       - name: Generate changelog
         run: git-cliff -o CHANGELOG.md
 
-      - name: Create PR if changelog changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet CHANGELOG.md && echo "No changelog changes" && exit 0
-          BRANCH="chore/changelog-update-$(date +%Y%m%d%H%M%S)"
-          git checkout -b "$BRANCH"
-          git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md"
-          git push -u origin "$BRANCH"
-          gh pr create --title "docs: update CHANGELOG.md" --body "Auto-generated changelog update by git-cliff." --base main --head "$BRANCH"
-          gh pr merge --squash --delete-branch --admin
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: update CHANGELOG.md"
+          branch: chore/auto-changelog
+          title: "docs: update CHANGELOG.md"
+          body: "Auto-generated changelog update by git-cliff."
+          delete-branch: true


### PR DESCRIPTION
## 关联 Issue

Closes #109

## 变更内容

- 替换手动 gh pr create 脚本为 `peter-evans/create-pull-request@v7` action
- 解决 `GitHub Actions is not permitted to create or approve pull requests` 错误
- changelog 变更时自动创建 PR 到 `chore/auto-changelog` 分支，需手动合并

## 测试

- [ ] CI 通过
- [ ] 下次 main 合并后 changelog PR 自动创建
